### PR TITLE
Checking definition types

### DIFF
--- a/np/lang/descriptions/test-utils.sld
+++ b/np/lang/descriptions/test-utils.sld
@@ -1,0 +1,18 @@
+(define-library (np lang descriptions test-utils)
+  ;;;
+  ;;; Utilities for description processing testing.
+  ;;;
+  (export assert-lang-error)
+
+  (import (scheme base)
+          (np lang descriptions types)
+          (te conditions define-assertion))
+
+  (begin
+
+    (define-assertion (assert-lang-error kind object)
+      (cond ((not (lang-error? object))                (assert-failure))
+            ((not (eq? (lang-error-kind object) kind)) (assert-failure))
+            (else (assert-success object)) ) )
+
+) )

--- a/np/lang/descriptions/test/test-typecheck.ss
+++ b/np/lang/descriptions/test/test-typecheck.ss
@@ -1,0 +1,328 @@
+(import (scheme base)
+        (np lang descriptions types)
+        (np lang descriptions test-utils)
+        (te base)
+        (te conditions assertions)
+        (te utils verify-test-case))
+
+; - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - ;
+
+(define non-symbols     `(42 "str" ,null? #\N () (a . d) #f (1 2 3) #(name)))
+(define non-procedures  `(42 "str" null? #\N () (a . d) #f (1 2 3) #(name)))
+(define non-lists       `(42 "str" null? ,null? #\N (a . d) #f #(x y z)))
+(define non-productions `(42 "str" ,null? #\N #f #(name)))
+
+(define invalid-names               (map list non-symbols))
+(define invalid-predicates          (map list non-procedures))
+(define invalid-meta-variables      (map list (map list non-symbols)))
+(define invalid-meta-variable-lists (map list non-lists))
+(define invalid-productions         (map list (map list non-productions)))
+(define invalid-production-lists    (map list non-productions))
+(define invalid-productions-nested `((((foo bar 42))) (((x (y . #(z))))) (((h i j ... k 4))) (((m . #\n)))))
+
+; - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - ;
+
+(define-test-case (typecheck:terminals "Type checking of terminals")
+
+  (define (make-checked-definition name predicate meta-vars)
+    (check-terminal-definition
+     (make-terminal-definition name predicate meta-vars) ) )
+
+  (define-test ("Normal terminal")
+    (assert-null (make-checked-definition 'number number? '(n))) )
+
+  (define-test ("Empty meta-variables")
+    (assert-null (make-checked-definition 'number number? '())) )
+
+  (define-test ("Empty name")
+    (assert-null (make-checked-definition '|| null? '())) )
+
+  (define-test ("Senseless predicate procedure")
+    (assert-null (make-checked-definition 'number * '(n))) )
+
+  (define-test ("Terminal type")
+    (let ((errors (check-terminal-definition 42)))
+      (assert-= 1 (length errors))
+      (assert-lang-error 'type:terminal-definition (car errors)) ) )
+
+  (define-test ("Terminal name" name)
+    #(invalid-names)
+    (let ((errors (make-checked-definition name null? '())))
+      (assert-= 1 (length errors))
+      (assert-lang-error 'type:terminal-name (car errors)) ) )
+
+  (define-test ("Terminal predicate" predicate)
+    #(invalid-predicates)
+    (let ((errors (make-checked-definition 'number predicate '())))
+      (assert-= 1 (length errors))
+      (assert-lang-error 'type:terminal-predicate (car errors)) ) )
+
+  (define-test ("Terminal meta-variable list" meta-vars)
+    #(invalid-meta-variable-lists)
+    (let ((errors (make-checked-definition 'number number? meta-vars)))
+      (assert-= 1 (length errors))
+      (assert-lang-error 'type:terminal-meta-var-list (car errors)) ) )
+
+  (define-test ("Terminal meta-variables" meta-vars)
+    #(invalid-meta-variables)
+    (let ((errors (make-checked-definition 'number number? meta-vars)))
+      (assert-= 1 (length errors))
+      (assert-lang-error 'type:terminal-meta-var (car errors)) ) )
+
+  (define-test ("Terminal name, predicate, meta-vars")
+    (let ((errors (make-checked-definition 1 2 '(3))))
+      (assert-= 3 (length errors))
+      (assert-lang-error 'type:terminal-name      (list-ref errors 0))
+      (assert-lang-error 'type:terminal-predicate (list-ref errors 1))
+      (assert-lang-error 'type:terminal-meta-var  (list-ref errors 2)) ) )
+)
+(verify-test-case! typecheck:terminals)
+
+; - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - ;
+
+(define-test-case (typecheck:terminal-mods "Type checking of terminal modifications")
+
+  (define (make-checked-modification name added-meta-vars removed-meta-vars)
+    (check-terminal-modification
+     (make-terminal-modification name added-meta-vars removed-meta-vars) ) )
+
+  (define-test ("Normal terminal modification")
+    (assert-null (make-checked-modification 'number '(n) '(m))) )
+
+  (define-test ("Empty meta-variables")
+    (assert-null (make-checked-modification 'number '() '())) )
+
+  (define-test ("Empty name")
+    (assert-null (make-checked-modification '|| '() '())) )
+
+  (define-test ("Terminal type")
+    (let ((errors (check-terminal-modification 42)))
+      (assert-= 1 (length errors))
+      (assert-lang-error 'type:terminal-modification (car errors)) ) )
+
+  (define-test ("Terminal name" name)
+    #(invalid-names)
+    (let ((errors (make-checked-modification name '() '())))
+      (assert-= 1 (length errors))
+      (assert-lang-error 'type:terminal-name (car errors)) ) )
+
+  (define-test ("Terminal meta-variable list (addition)" meta-vars)
+    #(invalid-meta-variable-lists)
+    (let ((errors (make-checked-modification 'number meta-vars '())))
+      (assert-= 1 (length errors))
+      (assert-lang-error 'type:terminal-added-meta-var-list (car errors)) ) )
+
+  (define-test ("Terminal meta-variable list (removal)" meta-vars)
+    #(invalid-meta-variable-lists)
+    (let ((errors (make-checked-modification 'number '() meta-vars)))
+      (assert-= 1 (length errors))
+      (assert-lang-error 'type:terminal-removed-meta-var-list (car errors)) ) )
+
+  (define-test ("Terminal meta-variables (addition)" meta-vars)
+    #(invalid-meta-variables)
+    (let ((errors (make-checked-modification 'number meta-vars '())))
+      (assert-= 1 (length errors))
+      (assert-lang-error 'type:terminal-added-meta-var (car errors)) ) )
+
+  (define-test ("Terminal meta-variables (removal)" meta-vars)
+    #(invalid-meta-variables)
+    (let ((errors (make-checked-modification 'number '() meta-vars)))
+      (assert-= 1 (length errors))
+      (assert-lang-error 'type:terminal-removed-meta-var (car errors)) ) )
+
+  (define-test ("Terminal name, meta-vars and list")
+    (let ((errors (make-checked-modification 1 '(2 3) '4)))
+      (assert-= 3 (length errors))
+      (assert-lang-error 'type:terminal-name                  (list-ref errors 0))
+      (assert-lang-error 'type:terminal-added-meta-var        (list-ref errors 1))
+      (assert-lang-error 'type:terminal-removed-meta-var-list (list-ref errors 2)) ) )
+
+  (define-test ("Terminal name, meta-vars (both types)")
+    (let ((errors (make-checked-modification 1 '(2 3) '(4))))
+      (assert-= 3 (length errors))
+      (assert-lang-error 'type:terminal-name             (list-ref errors 0))
+      (assert-lang-error 'type:terminal-added-meta-var   (list-ref errors 1))
+      (assert-lang-error 'type:terminal-removed-meta-var (list-ref errors 2)) ) )
+)
+(verify-test-case! typecheck:terminal-mods)
+
+; - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - ;
+
+(define-test-case (typecheck:nonterminals "Type checking of nonterminals")
+
+  (define (make-checked-definition name meta-vars productions)
+    (check-nonterminal-definition
+     (make-nonterminal-definition name meta-vars productions) ) )
+
+  (define-test ("Normal nonterminal")
+    (assert-null (make-checked-definition 'Number '(Num) '(N (n n)))) )
+
+  (define-test ("Empty meta-variables")
+    (assert-null (make-checked-definition 'Number '() '(N (n n)))) )
+
+  (define-test ("Empty productions")
+    (assert-null (make-checked-definition 'Number '() '())) )
+
+  (define-test ("Empty name")
+    (assert-null (make-checked-definition '|| '() '())) )
+
+  (define-test ("Nonterminal type")
+    (let ((errors (check-nonterminal-definition 42)))
+      (assert-= 1 (length errors))
+      (assert-lang-error 'type:nonterminal-definition (car errors)) ) )
+
+  (define-test ("Nonterminal name" name)
+    #(invalid-names)
+    (let ((errors (make-checked-definition name '() '())))
+      (assert-= 1 (length errors))
+      (assert-lang-error 'type:nonterminal-name (car errors)) ) )
+
+  (define-test ("Nonterminal meta-variable list" meta-vars)
+    #(invalid-meta-variable-lists)
+    (let ((errors (make-checked-definition 'Number meta-vars '())))
+      (assert-= 1 (length errors))
+      (assert-lang-error 'type:nonterminal-meta-var-list (car errors)) ) )
+
+  (define-test ("Nonterminal meta-variables" meta-vars)
+    #(invalid-meta-variables)
+    (let ((errors (make-checked-definition 'Number meta-vars '())))
+      (assert-= 1 (length errors))
+      (assert-lang-error 'type:nonterminal-meta-var (car errors)) ) )
+
+  (define-test ("Nonterminal production list" productions)
+    #(invalid-production-lists)
+    (let ((errors (make-checked-definition 'Number '() productions)))
+      (assert-= 1 (length errors))
+      (assert-lang-error 'type:nonterminal-production-list (car errors)) ) )
+
+  (define-test ("Nonterminal productions" productions)
+    #(invalid-productions)
+    (let ((errors (make-checked-definition 'Number '() productions)))
+      (assert-= 1 (length errors))
+      (assert-lang-error 'type:nonterminal-production (car errors)) ) )
+
+  (define-test ("Nonterminal productions nested" productions)
+    #(invalid-productions-nested)
+    (let ((errors (make-checked-definition 'Number '() productions)))
+      (assert-= 1 (length errors))
+      (assert-lang-error 'type:nonterminal-production (car errors)) ) )
+
+  (define-test ("Nonterminal name, meta-vars and productions")
+    (let ((errors (make-checked-definition 1 '(2) '(3))))
+      (assert-= 3 (length errors))
+      (assert-lang-error 'type:nonterminal-name       (list-ref errors 0))
+      (assert-lang-error 'type:nonterminal-meta-var   (list-ref errors 1))
+      (assert-lang-error 'type:nonterminal-production (list-ref errors 2)) ) )
+)
+(verify-test-case! typecheck:nonterminals)
+
+; - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - ;
+
+(define-test-case (typecheck:nonterminal-mods "Type checking of nonterminal modifications")
+
+  (define (make-checked-modification name added-meta-vars removed-meta-vars added-productions removed-productions)
+    (check-nonterminal-modification
+     (make-nonterminal-modification name added-meta-vars removed-meta-vars added-productions removed-productions) ) )
+
+  (define-test ("Normal nonterminal modification")
+    (assert-null (make-checked-modification 'Number '(Num) '(n (r i)) '(Number) '((C r i)))) )
+
+  (define-test ("Empty meta-variables")
+    (assert-null (make-checked-modification 'Number '() '(n (r i)) '() '((C r i)))) )
+
+  (define-test ("Empty productions")
+    (assert-null (make-checked-modification 'Number '() '() '() '())) )
+
+  (define-test ("Empty name")
+    (assert-null (make-checked-modification '|| '() '() '() '())) )
+
+  (define-test ("Nonterminal type")
+    (let ((errors (check-nonterminal-modification 42)))
+      (assert-= 1 (length errors))
+      (assert-lang-error 'type:nonterminal-modification (car errors)) ) )
+
+  (define-test ("Nonterminal name" name)
+    #(invalid-names)
+    (let ((errors (make-checked-modification name '() '() '() '())))
+      (assert-= 1 (length errors))
+      (assert-lang-error 'type:nonterminal-name (car errors)) ) )
+
+  (define-test ("Nonterminal meta-variable list (addition)" meta-vars)
+    #(invalid-meta-variable-lists)
+    (let ((errors (make-checked-modification 'Number meta-vars '() '() '())))
+      (assert-= 1 (length errors))
+      (assert-lang-error 'type:nonterminal-added-meta-var-list (car errors)) ) )
+
+  (define-test ("Nonterminal meta-variable list (removal)" meta-vars)
+    #(invalid-meta-variable-lists)
+    (let ((errors (make-checked-modification 'Number '() '() meta-vars '())))
+      (assert-= 1 (length errors))
+      (assert-lang-error 'type:nonterminal-removed-meta-var-list (car errors)) ) )
+
+  (define-test ("Nonterminal meta-variables (addition)" meta-vars)
+    #(invalid-meta-variables)
+    (let ((errors (make-checked-modification 'Number meta-vars '() '() '())))
+      (assert-= 1 (length errors))
+      (assert-lang-error 'type:nonterminal-added-meta-var (car errors)) ) )
+
+  (define-test ("Nonterminal meta-variables (removal)" meta-vars)
+    #(invalid-meta-variables)
+    (let ((errors (make-checked-modification 'Number '() '() meta-vars '())))
+      (assert-= 1 (length errors))
+      (assert-lang-error 'type:nonterminal-removed-meta-var (car errors)) ) )
+
+  (define-test ("Nonterminal production list (addition)" productions)
+    #(invalid-production-lists)
+    (let ((errors (make-checked-modification 'Number '() productions '() '())))
+      (assert-= 1 (length errors))
+      (assert-lang-error 'type:nonterminal-added-production-list (car errors)) ) )
+
+  (define-test ("Nonterminal production list (removal)" productions)
+    #(invalid-production-lists)
+    (let ((errors (make-checked-modification 'Number '() '() '() productions)))
+      (assert-= 1 (length errors))
+      (assert-lang-error 'type:nonterminal-removed-production-list (car errors)) ) )
+
+  (define-test ("Nonterminal productions (addition)" productions)
+    #(invalid-productions)
+    (let ((errors (make-checked-modification 'Number '() productions '() '())))
+      (assert-= 1 (length errors))
+      (assert-lang-error 'type:nonterminal-added-production (car errors)) ) )
+
+  (define-test ("Nonterminal productions (removal)" productions)
+    #(invalid-productions)
+    (let ((errors (make-checked-modification 'Number '() '() '() productions)))
+      (assert-= 1 (length errors))
+      (assert-lang-error 'type:nonterminal-removed-production (car errors)) ) )
+
+  (define-test ("Nonterminal productions nested (addition)" productions)
+    #(invalid-productions-nested)
+    (let ((errors (make-checked-modification 'Number '() productions '() '())))
+      (assert-= 1 (length errors))
+      (assert-lang-error 'type:nonterminal-added-production (car errors)) ) )
+
+  (define-test ("Nonterminal productions nested (removal)" productions)
+    #(invalid-productions-nested)
+    (let ((errors (make-checked-modification 'Number '() '() '() productions)))
+      (assert-= 1 (length errors))
+      (assert-lang-error 'type:nonterminal-removed-production (car errors)) ) )
+
+  (define-test ("Nonterminal name, meta-vars, productions and list")
+    (let ((errors (make-checked-modification 1 '(2 3) '4 '5 '(6 7))))
+      (assert-= 5 (length errors))
+      (assert-lang-error 'type:nonterminal-name                  (list-ref errors 0))
+      (assert-lang-error 'type:nonterminal-added-meta-var        (list-ref errors 1))
+      (assert-lang-error 'type:nonterminal-removed-meta-var-list (list-ref errors 2))
+      (assert-lang-error 'type:nonterminal-added-production-list (list-ref errors 3))
+      (assert-lang-error 'type:nonterminal-removed-production    (list-ref errors 4)) ) )
+
+  (define-test ("Nonterminal name, meta-vars, productions (both types)")
+    (let ((errors (make-checked-modification 1 '(2 3) '(4) '(5 6) '(7 #(8)))))
+      (assert-= 5 (length errors))
+      (assert-lang-error 'type:nonterminal-name               (list-ref errors 0))
+      (assert-lang-error 'type:nonterminal-added-meta-var     (list-ref errors 1))
+      (assert-lang-error 'type:nonterminal-removed-meta-var   (list-ref errors 2))
+      (assert-lang-error 'type:nonterminal-added-production   (list-ref errors 3))
+      (assert-lang-error 'type:nonterminal-removed-production (list-ref errors 4)) ) )
+)
+(verify-test-case! typecheck:nonterminal-mods)

--- a/np/lang/descriptions/types.sld
+++ b/np/lang/descriptions/types.sld
@@ -15,14 +15,14 @@
           nonterminal-definition nonterminal-definition? make-nonterminal-definition
           nonterminal-name
           nonterminal-meta-variables
-          nonterminal-production-descriptions
+          nonterminal-production-definitions
 
           nonterminal-modification nonterminal-modification? make-nonterminal-modification
           modified-nonterminal-name
           modified-nonterminal-added-meta-variables
-          modified-nonterminal-added-production-descriptions
+          modified-nonterminal-added-production-definitions
           modified-nonterminal-removed-meta-variables
-          modified-nonterminal-removed-production-descriptions)
+          modified-nonterminal-removed-production-definitions)
 
   (import (scheme base))
 
@@ -46,21 +46,21 @@
       (removed-meta-variables modified-terminal-removed-meta-variables) )
 
     (define-record-type nonterminal-definition
-      (make-nonterminal-definition name meta-variables production-descriptions)
+      (make-nonterminal-definition name meta-variables production-definitions)
       nonterminal-definition?
-      (name                    nonterminal-name)
-      (meta-variables          nonterminal-meta-variables)
-      (production-descriptions nonterminal-production-descriptions) )
+      (name                   nonterminal-name)
+      (meta-variables         nonterminal-meta-variables)
+      (production-definitions nonterminal-production-definitions) )
 
     (define-record-type nonterminal-modification
       (make-nonterminal-modification name
-        added-meta-variables added-production-descriptions
-        removed-meta-variables removed-production-descriptions )
+        added-meta-variables added-production-definitions
+        removed-meta-variables removed-production-definitions )
       nonterminal-modification?
-      (name                            modified-nonterminal-name)
-      (added-meta-variables            modified-nonterminal-added-meta-variables)
-      (added-production-descriptions   modified-nonterminal-added-production-descriptions)
-      (removed-meta-variables          modified-nonterminal-removed-meta-variables)
-      (removed-production-descriptions modified-nonterminal-removed-production-descriptions) )
+      (name                           modified-nonterminal-name)
+      (added-meta-variables           modified-nonterminal-added-meta-variables)
+      (added-production-definitions   modified-nonterminal-added-production-definitions)
+      (removed-meta-variables         modified-nonterminal-removed-meta-variables)
+      (removed-production-definitions modified-nonterminal-removed-production-definitions) )
 
 ) )

--- a/np/lang/descriptions/types.sld
+++ b/np/lang/descriptions/types.sld
@@ -22,7 +22,12 @@
           modified-nonterminal-added-meta-variables
           modified-nonterminal-added-production-definitions
           modified-nonterminal-removed-meta-variables
-          modified-nonterminal-removed-production-definitions)
+          modified-nonterminal-removed-production-definitions
+
+          lang-error lang-error?
+          lang-error-kind
+          lang-error-object
+          lang-error-causes)
 
   (import (scheme base))
 
@@ -62,5 +67,19 @@
       (added-production-definitions   modified-nonterminal-added-production-definitions)
       (removed-meta-variables         modified-nonterminal-removed-meta-variables)
       (removed-production-definitions modified-nonterminal-removed-production-definitions) )
+
+    ;;;
+    ;;; Error report object
+    ;;;
+
+    (define-record-type %lang-error
+      (make-lang-error kind object causes)
+      lang-error?
+      (kind   lang-error-kind)
+      (object lang-error-object)
+      (causes lang-error-causes) )
+
+    (define (lang-error kind object . causes)
+      (make-lang-error kind object causes) )
 
 ) )

--- a/np/lang/descriptions/types.sld
+++ b/np/lang/descriptions/types.sld
@@ -2,22 +2,30 @@
   ;;;
   ;;; Types used in processing of language definitions and descriptions
   ;;;
-  (export terminal-definition terminal-definition? make-terminal-definition
+  (export terminal-definition terminal-definition?
+          make-terminal-definition
+          check-terminal-definition
           terminal-name
           terminal-predicate
           terminal-meta-variables
 
-          terminal-modification terminal-modification? make-terminal-modification
+          terminal-modification terminal-modification?
+          make-terminal-modification
+          check-terminal-modification
           modified-terminal-name
           modified-terminal-added-meta-variables
           modified-terminal-removed-meta-variables
 
-          nonterminal-definition nonterminal-definition? make-nonterminal-definition
+          nonterminal-definition nonterminal-definition?
+          make-nonterminal-definition
+          check-nonterminal-definition
           nonterminal-name
           nonterminal-meta-variables
           nonterminal-production-definitions
 
-          nonterminal-modification nonterminal-modification? make-nonterminal-modification
+          nonterminal-modification nonterminal-modification?
+          make-nonterminal-modification
+          check-nonterminal-modification
           modified-nonterminal-name
           modified-nonterminal-added-meta-variables
           modified-nonterminal-added-production-definitions
@@ -29,7 +37,8 @@
           lang-error-object
           lang-error-causes)
 
-  (import (scheme base))
+  (import (scheme base)
+          (only (srfi 1) filter))
 
   (begin
     ;;;
@@ -81,5 +90,93 @@
 
     (define (lang-error kind object . causes)
       (make-lang-error kind object causes) )
+
+    ;;;
+    ;;; Type check helpers
+    ;;;
+
+    (define-syntax collect-errors
+      (syntax-rules ()
+        ((_ object clauses ...)
+         (let ((errors '()))
+           (collect* errors object clauses ...)
+           (reverse errors) )) ) )
+
+    (define-syntax collect*
+      (syntax-rules ()
+        ((_ errors object ((predicate expr) kind clauses ...) ...)
+         (begin
+           (let ((value expr))
+             (if (predicate value)
+                 (collect* errors object clauses ...)
+                 (set! errors (cons (lang-error kind object value) errors)) ) ) ...)) ) )
+
+    (define (meta-variable? x)
+      (symbol? x) )
+
+    (define (production? x)
+      (or (null? x)
+          (symbol? x)
+          (and (pair? x)
+               (production? (car x))
+               (production? (cdr x)) ) ) )
+
+    (define (invalid-meta-variables list)
+      (filter (lambda (x) (not (meta-variable? x))) list) )
+
+    (define (invalid-productions list)
+      (filter (lambda (x) (not (production? x))) list) )
+
+    ;;;
+    ;;; Type checks
+    ;;;
+
+    (define (check-terminal-definition x)
+      (collect-errors x
+        ((terminal-definition? x)                        'type:terminal-definition
+          ((symbol? (terminal-name x))                   'type:terminal-name)
+          ((procedure? (terminal-predicate x))           'type:terminal-predicate)
+          ((list? (terminal-meta-variables x))           'type:terminal-meta-var-list
+            ((null? (invalid-meta-variables (terminal-meta-variables x)))
+                                                         'type:terminal-meta-var ) ) ) ) )
+
+    (define (check-terminal-modification x)
+      (collect-errors x
+        ((terminal-modification? x)                              'type:terminal-modification
+          ((symbol? (modified-terminal-name x))                  'type:terminal-name)
+          ((list? (modified-terminal-added-meta-variables x))    'type:terminal-added-meta-var-list
+            ((null? (invalid-meta-variables (modified-terminal-added-meta-variables x)))
+                                                                 'type:terminal-added-meta-var ) )
+          ((list? (modified-terminal-removed-meta-variables x))  'type:terminal-removed-meta-var-list
+            ((null? (invalid-meta-variables (modified-terminal-removed-meta-variables x)))
+                                                                 'type:terminal-removed-meta-var ) ) ) ) )
+
+    (define (check-nonterminal-definition x)
+      (collect-errors x
+        ((nonterminal-definition? x)                                'type:nonterminal-definition
+          ((symbol? (nonterminal-name x))                           'type:nonterminal-name)
+          ((list? (nonterminal-meta-variables x))                   'type:nonterminal-meta-var-list
+            ((null? (invalid-meta-variables (nonterminal-meta-variables x)))
+                                                                    'type:nonterminal-meta-var ) )
+          ((list? (nonterminal-production-definitions x))           'type:nonterminal-production-list
+            ((null? (invalid-productions (nonterminal-production-definitions x)))
+                                                                    'type:nonterminal-production ) ) ) ) )
+
+    (define (check-nonterminal-modification x)
+      (collect-errors x
+        ((nonterminal-modification? x)                                      'type:nonterminal-modification
+          ((symbol? (modified-nonterminal-name x))                          'type:nonterminal-name)
+          ((list? (modified-nonterminal-added-meta-variables x))            'type:nonterminal-added-meta-var-list
+            ((null? (invalid-meta-variables (modified-nonterminal-added-meta-variables x)))
+                                                                            'type:nonterminal-added-meta-var) )
+          ((list? (modified-nonterminal-removed-meta-variables x))          'type:nonterminal-removed-meta-var-list
+            ((null? (invalid-meta-variables (modified-nonterminal-removed-meta-variables x)))
+                                                                            'type:nonterminal-removed-meta-var) )
+          ((list? (modified-nonterminal-added-production-definitions x))    'type:nonterminal-added-production-list
+            ((null? (invalid-productions (modified-nonterminal-added-production-definitions x)))
+                                                                            'type:nonterminal-added-production) )
+          ((list? (modified-nonterminal-removed-production-definitions x))  'type:nonterminal-removed-production-list
+            ((null? (invalid-productions (modified-nonterminal-removed-production-definitions x)))
+                                                                            'type:nonterminal-removed-production) ) ) ) )
 
 ) )

--- a/np/lang/macros/test/codegen/test-codegen-nonterminals.ss
+++ b/np/lang/macros/test/codegen/test-codegen-nonterminals.ss
@@ -23,10 +23,10 @@
     (assert-= n (length list))
     (assert-true (every nonterminal-definition? list)) )
 
-  (define (assert-def def name meta-variables production-descriptions)
-    (assert-eq    name                    (nonterminal-name def))
-    (assert-equal meta-variables          (nonterminal-meta-variables def))
-    (assert-equal production-descriptions (nonterminal-production-descriptions def)) )
+  (define (assert-def def name meta-variables production-definitions)
+    (assert-eq    name                   (nonterminal-name def))
+    (assert-equal meta-variables         (nonterminal-meta-variables def))
+    (assert-equal production-definitions (nonterminal-production-definitions def)) )
 
   (define-test ("Empty list")
     (for defs '()
@@ -75,10 +75,10 @@
     (assert-= n (length list))
     (assert-true (every nonterminal-definition? list)) )
 
-  (define (assert-def def name meta-variables production-descriptions)
-    (assert-eq    name                    (nonterminal-name def))
-    (assert-equal meta-variables          (nonterminal-meta-variables def))
-    (assert-equal production-descriptions (nonterminal-production-descriptions def)) )
+  (define (assert-def def name meta-variables production-definitions)
+    (assert-eq    name                   (nonterminal-name def))
+    (assert-equal meta-variables         (nonterminal-meta-variables def))
+    (assert-equal production-definitions (nonterminal-production-definitions def)) )
 
   (define-test ("Empty list")
     (for defs '()
@@ -162,12 +162,12 @@
     (assert-= n (length list))
     (assert-true (every nonterminal-modification? list)) )
 
-  (define (assert-mod modified name added-meta-vars added-production-descriptions removed-meta-vars removed-production-descriptions)
-    (assert-eq    name                            (modified-nonterminal-name modified))
-    (assert-equal added-meta-vars                 (modified-nonterminal-added-meta-variables modified))
-    (assert-equal added-production-descriptions   (modified-nonterminal-added-production-descriptions modified))
-    (assert-equal removed-meta-vars               (modified-nonterminal-removed-meta-variables modified))
-    (assert-equal removed-production-descriptions (modified-nonterminal-removed-production-descriptions modified)) )
+  (define (assert-mod modified name added-meta-vars added-production-definitions removed-meta-vars removed-production-definitions)
+    (assert-eq    name                           (modified-nonterminal-name modified))
+    (assert-equal added-meta-vars                (modified-nonterminal-added-meta-variables modified))
+    (assert-equal added-production-definitions   (modified-nonterminal-added-production-definitions modified))
+    (assert-equal removed-meta-vars              (modified-nonterminal-removed-meta-variables modified))
+    (assert-equal removed-production-definitions (modified-nonterminal-removed-production-definitions modified)) )
 
   (define-test ("Empty list")
     (for mods '()


### PR DESCRIPTION
This adds typechecking of terminal and nonterminal definitions and modifications.

It also exemplifies the way I want error reporting to be done: verifying procedures return lists of errors they encounter during processing.

These typecheckers are _pure verifiers_, their single job is to return such list of errors. Other procedures could do some meaningful stuff. For those I plan to use continuable exceptions to throw errors up through the call stack and get some replacement objects back to continue processing.

This will allow to capture more errors in a single pass, not just stop at the first one as a retard.

Partial fulfillment of issue #1
