### PR TITLE
Extending language definitions

### DIFF
--- a/np/lang/descriptions/definitions.sld
+++ b/np/lang/descriptions/definitions.sld
@@ -1,6 +1,6 @@
-(define-library (np lang descriptions types)
+(define-library (np lang descriptions definitions)
   ;;;
-  ;;; Types used in processing of language definitions and descriptions
+  ;;; Types and utilities used in processing of language definitions
   ;;;
   (export terminal-definition?
           make-terminal-definition

--- a/np/lang/descriptions/errors.sld
+++ b/np/lang/descriptions/errors.sld
@@ -1,0 +1,28 @@
+(define-library (np lang descriptions errors)
+  ;;;
+  ;;; Error handling utilities
+  ;;;
+  (export lang-error
+          lang-error?
+          lang-error-kind
+          lang-error-object
+          lang-error-causes)
+
+  (import (scheme base))
+
+  (begin
+    ;;;
+    ;;; Error report object
+    ;;;
+
+    (define-record-type %lang-error
+      (make-lang-error kind object causes)
+      lang-error?
+      (kind   lang-error-kind)
+      (object lang-error-object)
+      (causes lang-error-causes) )
+
+    (define (lang-error kind object . causes)
+      (make-lang-error kind object causes) )
+
+) )

--- a/np/lang/descriptions/extension.sld
+++ b/np/lang/descriptions/extension.sld
@@ -1,0 +1,148 @@
+(define-library (np lang descriptions extension)
+  ;;;
+  ;;; Language extending
+  ;;;
+  (export append-terminal-definitions
+          remove-terminal-definitions
+          modify-terminal-definitions
+
+          append-nonterminal-definitions
+          remove-nonterminal-definitions
+          modify-nonterminal-definitions)
+
+  (import (scheme base)
+          (srfi 1)   ; list library
+          (np lang descriptions definitions)
+          (np lang descriptions errors)
+          (np lang descriptions unification))
+
+  (begin
+    ;;;
+    ;;; Helpers
+    ;;;
+
+    (define (find-duplicates list equal?)
+      (let loop ((duplicates '()) (list list))
+        (if (null? list)
+            duplicates
+            (if (member (car list) (cdr list) equal?)
+                (loop (cons (car list) duplicates) (cdr list))
+                (loop duplicates (cdr list)) ) ) ) )
+
+    (define (find-missing present removed equal?)
+      (remove
+       (lambda (x) (member x present equal?))
+       removed ) )
+
+    (define (apply-modifications present added removed equal?)
+      (append added
+       (remove
+        (lambda (x) (member x removed equal?))
+        present ) ) )
+
+    (define (check-missing/duplicates! present removed equal? context kind-duplicates kind-missing)
+      (let ((duplicates (find-duplicates removed equal?)))
+        (unless (null? duplicates)
+          (raise-continuable (lang-error kind-duplicates context duplicates)) ) )
+      (let ((missing (find-missing present removed equal?)))
+        (unless (null? missing)
+          (raise-continuable (lang-error kind-missing context missing)) ) ) )
+
+    ;;;
+    ;;; Terminals
+    ;;;
+
+    (define (append-terminal-definitions old-terminals new-terminals)
+      (append old-terminals new-terminals) )
+
+    (define (remove-terminal-definitions terminals removed-names)
+      (check-missing/duplicates!
+        (map terminal-name terminals)
+        removed-names eq? #f
+        'ext:term:remove-duplicate
+        'ext:term:remove-missing )
+      (remove
+        (lambda (terminal) (memq (terminal-name terminal) removed-names))
+        terminals ) )
+
+    (define (modify-terminal-definitions terminals modifications)
+      (check-missing/duplicates!
+        (map terminal-name terminals)
+        (map modified-terminal-name modifications)
+        eq? #f
+        'ext:term:modify-duplicate
+        'ext:term:modify-missing )
+      (map
+        (lambda (terminal)
+          (define (with-name name)
+            (lambda (modification)
+              (eq? (modified-terminal-name modification) name) ) )
+          (let ((modification (find (with-name (terminal-name terminal)) modifications)))
+            (if modification
+                (modified-terminal terminal modification)
+                terminal ) ) )
+        terminals ) )
+
+    (define (modified-terminal terminal modification)
+      (with-terminal-definition terminal (name predicate meta-vars)
+        (with-terminal-modification modification (name meta-vars+ meta-vars-)
+          (check-missing/duplicates!
+            meta-vars meta-vars- eq? modification
+            'ext:term:modify:meta-var-remove-duplicate
+            'ext:term:modify:meta-var-remove-missing )
+          (make-terminal-definition name predicate
+           (apply-modifications meta-vars meta-vars+ meta-vars- eq?) ) ) ) )
+
+    ;;;
+    ;;; Nonterminals
+    ;;;
+
+    (define (append-nonterminal-definitions old-nonterminals new-nonterminals)
+      (append old-nonterminals new-nonterminals) )
+
+    (define (remove-nonterminal-definitions nonterminals removed-names)
+      (check-missing/duplicates!
+        (map nonterminal-name nonterminals)
+        removed-names eq? #f
+        'ext:nonterm:remove-duplicate
+        'ext:nonterm:remove-missing )
+      (remove
+        (lambda (nonterminal) (memq (nonterminal-name nonterminal) removed-names))
+        nonterminals ) )
+
+    (define (modify-nonterminal-definitions terminals nonterminals modifications)
+      (check-missing/duplicates!
+        (map nonterminal-name nonterminals)
+        (map modified-nonterminal-name modifications)
+        eq? #f
+        'ext:nonterm:modify-duplicate
+        'ext:nonterm:modify-missing )
+      (let* ((mapping (make-meta-var-mapping terminals nonterminals))
+             (productions-equal? (lambda (a b) (productions-equal? mapping a b))))
+        (map
+          (lambda (nonterminal)
+            (define (with-name name)
+              (lambda (modification)
+                (eq? (modified-nonterminal-name modification) name) ) )
+            (let ((modification (find (with-name (nonterminal-name nonterminal)) modifications)))
+              (if modification
+                  (modified-nonterminal nonterminal modification productions-equal?)
+                  nonterminal ) ) )
+          nonterminals ) ) )
+
+    (define (modified-nonterminal nonterminal modification productions-equal?)
+      (with-nonterminal-definition nonterminal (name meta-vars productions)
+        (with-nonterminal-modification modification (name meta-vars+ meta-vars- productions+ productions-)
+          (check-missing/duplicates!
+            meta-vars meta-vars- eq? modification
+            'ext:nonterm:modify:meta-var-remove-duplicate
+            'ext:nonterm:modify:meta-var-remove-missing )
+          (check-missing/duplicates!
+            productions productions- productions-equal? modification
+            'ext:nonterm:modify:production-remove-duplicate
+            'ext:nonterm:modify:production-remove-missing )
+          (make-nonterminal-definition name
+           (apply-modifications meta-vars meta-vars+ meta-vars- eq?)
+           (apply-modifications productions productions+ productions- productions-equal?) ) ) ) )
+
+) )

--- a/np/lang/descriptions/syntax.sld
+++ b/np/lang/descriptions/syntax.sld
@@ -11,6 +11,7 @@
 
   (import (scheme base)
           (only (srfi 1) every filter remove)
+          (np lang descriptions errors)
           (np lang descriptions types))
 
   (begin

--- a/np/lang/descriptions/syntax.sld
+++ b/np/lang/descriptions/syntax.sld
@@ -11,8 +11,8 @@
 
   (import (scheme base)
           (only (srfi 1) every filter remove)
-          (np lang descriptions errors)
-          (np lang descriptions types))
+          (np lang descriptions definitions)
+          (np lang descriptions errors))
 
   (begin
     ;;;

--- a/np/lang/descriptions/test-utils.sld
+++ b/np/lang/descriptions/test-utils.sld
@@ -5,6 +5,7 @@
   (export assert-lang-error)
 
   (import (scheme base)
+          (np lang descriptions errors)
           (np lang descriptions types)
           (te conditions define-assertion))
 

--- a/np/lang/descriptions/test/test-extension.ss
+++ b/np/lang/descriptions/test/test-extension.ss
@@ -1,0 +1,654 @@
+(import (scheme base)
+        (only (srfi 1) lset=)
+        (np lang descriptions definitions)
+        (np lang descriptions errors)
+        (np lang descriptions extension)
+        (np lang descriptions test utils)
+        (te base)
+        (te conditions assertions)
+        (te utils verify-test-case))
+
+; - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - ;
+
+(define (terminal-definitions-equal? a b)
+  (and (eq?       (terminal-name a)           (terminal-name b))
+       (eqv?      (terminal-predicate a)      (terminal-predicate b))
+       (lset= eq? (terminal-meta-variables a) (terminal-meta-variables b)) ) )
+
+(define (nonterminal-definitions-equal? a b)
+  (and (eq?          (nonterminal-name a)                   (nonterminal-name b))
+       (lset= eq?    (nonterminal-meta-variables a)         (nonterminal-meta-variables b))
+       (lset= equal? (nonterminal-production-definitions a) (nonterminal-production-definitions b)) ) )
+
+(define (assert-term-defs-equal expected actual)
+  (assert-true (list? expected))
+  (assert-true (list? actual))
+  (assert-true (lset= terminal-definitions-equal? expected actual)) )
+
+(define (assert-nonterm-defs-equal expected actual)
+  (assert-true (list? expected))
+  (assert-true (list? actual))
+  (assert-true (lset= nonterminal-definitions-equal? expected actual)) )
+
+(define (collect-errors body handler)
+  (let ((errors '()))
+    (with-exception-handler
+      (lambda (condition)
+        (if (lang-error? condition)
+            (set! errors (cons condition errors))
+            (raise condition) ) )
+      body )
+    (handler (reverse errors)) ) )
+
+; - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - ;
+
+(define-test-case (extension:terminals:add "Terminal addition")
+
+  (define number  (make-terminal-definition 'number number? '(n)))
+  (define number1 (make-terminal-definition 'number number? '(u)))
+  (define number2 (make-terminal-definition 'number number? '(m)))
+  (define string  (make-terminal-definition 'string string? '(s)))
+  (define symbol  (make-terminal-definition 'symbol symbol? '(s)))
+
+  (define-test ("Empty lists")
+    (assert-equal '() (append-terminal-definitions '() '())) )
+
+  (define-test ("Normal addition")
+    (assert-term-defs-equal (list number string)
+     (append-terminal-definitions (list number) (list string))) )
+
+  (define-test ("Adding empty list")
+    (assert-term-defs-equal (list number)
+     (append-terminal-definitions (list number) '())) )
+
+  (define-test ("Adding to empty list")
+    (assert-term-defs-equal (list number)
+     (append-terminal-definitions '() (list number))) )
+
+  (define-test ("Does not track meta-variable duplication")
+    (assert-term-defs-equal (list symbol string)
+     (append-terminal-definitions (list symbol) (list string))) )
+
+  (define-test ("Allows to add multiple of the same name")
+    (assert-term-defs-equal (list string number number1)
+     (append-terminal-definitions (list string) (list number number1))) )
+
+  (define-test ("Allows to add existing name")
+    (assert-term-defs-equal (list string number number1)
+     (append-terminal-definitions (list string number) (list number1))) )
+
+  (define-test ("Allows to add multiple of the same existing name")
+    (assert-term-defs-equal (list string number number1 number2)
+     (append-terminal-definitions (list string number) (list number1 number2))) )
+
+  (define-test ("Does not fail on preexisting duplicates")
+    (assert-term-defs-equal (list number1 number2 string)
+     (append-terminal-definitions (list number1 number2) (list string))) )
+)
+(verify-test-case! extension:terminals:add)
+
+; - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - ;
+
+(define-test-case (extension:terminals:rem "Terminal removal")
+
+  (define number (make-terminal-definition 'number number? '(n)))
+  (define string (make-terminal-definition 'string string? '(s)))
+  (define symbol (make-terminal-definition 'symbol symbol? '(s)))
+
+  (define-test ("Empty lists")
+    (assert-equal '() (remove-terminal-definitions '() '())) )
+
+  (define-test ("Normal removal")
+    (assert-term-defs-equal (list number)
+     (remove-terminal-definitions (list number string) '(string))) )
+
+  (define-test ("Removing an empty list")
+    (assert-term-defs-equal (list number string)
+     (remove-terminal-definitions (list number string) '())) )
+
+  (define-test ("Removing everything")
+    (assert-term-defs-equal '()
+     (remove-terminal-definitions (list number string symbol) '(string number symbol))) )
+
+  (define-test ("Removal of nonexistent definitions")
+    (collect-errors
+     (lambda ()
+       (assert-term-defs-equal (list number string)
+        (remove-terminal-definitions (list number string) '(other)) ) )
+     (lambda (errors)
+       (assert-= 1 (length errors))
+       (assert-lang-error 'ext:term:remove-missing (car errors)) ) ) )
+
+  (define-test ("Removal of multiple nonexistent definitions")
+    (collect-errors
+     (lambda ()
+       (assert-term-defs-equal (list number string)
+        (remove-terminal-definitions (list number string) '(other another)) ) )
+     (lambda (errors)
+       (assert-= 1 (length errors))
+       (assert-lang-error 'ext:term:remove-missing (car errors)) ) ) )
+
+  (define-test ("Duplicate removals")
+    (collect-errors
+     (lambda ()
+       (assert-term-defs-equal (list string)
+        (remove-terminal-definitions (list number string) '(number number)) ) )
+     (lambda (errors)
+       (assert-= 1 (length errors))
+       (assert-lang-error 'ext:term:remove-duplicate (car errors)) ) ) )
+
+  (define-test ("Duplicate removal of nonexistent definitions")
+    (collect-errors
+     (lambda ()
+       (assert-term-defs-equal (list number)
+        (remove-terminal-definitions (list number string) '(other other string)) ) )
+     (lambda (errors)
+       (assert-= 2 (length errors))
+       (assert-lang-error 'ext:term:remove-duplicate (car errors))
+       (assert-lang-error 'ext:term:remove-missing (cadr errors)) ) ) )
+)
+(verify-test-case! extension:terminals:rem)
+
+; - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - ;
+
+(define-test-case (extension:terminals:mod "Terminal modification")
+
+  (define number (make-terminal-definition 'number number? '(n)))
+  (define string (make-terminal-definition 'string string? '(s)))
+  (define symbol (make-terminal-definition 'symbol symbol? '(s)))
+
+  (define number* (make-terminal-definition 'number number? '(n m)))
+  (define symbol* (make-terminal-definition 'symbol symbol? '(sym)))
+
+  (define number0 (make-terminal-definition 'number number? '()))
+  (define number2 (make-terminal-definition 'number number? '(n n)))
+  (define number3 (make-terminal-definition 'number number? '(n n n)))
+
+  (define-test ("Empty lists")
+    (assert-equal '() (modify-terminal-definitions '() '())) )
+
+  (define-test ("Normal modification (adding variables)")
+    (assert-term-defs-equal (list number* string)
+     (modify-terminal-definitions (list number string)
+      (list (make-terminal-modification 'number '(m) '())) ) ) )
+
+  (define-test ("Normal modification (removing variables)")
+    (assert-term-defs-equal (list number)
+     (modify-terminal-definitions (list number*)
+      (list (make-terminal-modification 'number '() '(m))) ) ) )
+
+  (define-test ("Normal modification (replacing variables)")
+    (assert-term-defs-equal (list number symbol*)
+     (modify-terminal-definitions (list number symbol)
+      (list (make-terminal-modification 'symbol '(sym) '(s))) ) ) )
+
+  (define-test ("Not modifying anything (empty list)")
+    (assert-term-defs-equal (list number string)
+     (modify-terminal-definitions (list number string) '())) )
+
+  (define-test ("Not modifying anything (with noops)")
+    (assert-term-defs-equal (list number string)
+     (modify-terminal-definitions (list number string)
+      (list (make-terminal-modification 'number '() '())
+            (make-terminal-modification 'string '() '()) ) ) ) )
+
+  (define-test ("Allows to add duplicate variables")
+    (assert-term-defs-equal (list number2)
+     (modify-terminal-definitions (list number)
+      (list (make-terminal-modification 'number '(n) '())) ) ) )
+
+  (define-test ("Allows to add duplicate variables (2)")
+    (assert-term-defs-equal (list number3)
+     (modify-terminal-definitions (list number)
+      (list (make-terminal-modification 'number '(n n) '())) ) ) )
+
+  (define-test ("Allows to remove all variables")
+    (assert-term-defs-equal (list number0)
+     (modify-terminal-definitions (list number)
+      (list (make-terminal-modification 'number '() '(n))) ) ) )
+
+  (define-test ("Allows to remove and re-add a variable")
+    (assert-term-defs-equal (list string)
+     (modify-terminal-definitions (list string)
+      (list (make-terminal-modification 'string '(s) '(s))) ) ) )
+
+  (define-test ("Modification of nonexistent definition")
+    (collect-errors
+     (lambda ()
+       (assert-term-defs-equal (list number string)
+        (modify-terminal-definitions (list number string)
+         (list (make-terminal-modification 'symbol '(s) '(sym))) ) ) )
+     (lambda (errors)
+       (assert-= 1 (length errors))
+       (assert-lang-error 'ext:term:modify-missing (car errors)) ) ) )
+
+  (define-test ("Duplicate modification")
+    (collect-errors
+     (lambda ()
+       ; no assumptions about what we get as result in this case
+       (modify-terminal-definitions (list number)
+        (list (make-terminal-modification 'number '(m) '())
+              (make-terminal-modification 'number '() '(n)) ) ) )
+     (lambda (errors)
+       (assert-= 1 (length errors))
+       (assert-lang-error 'ext:term:modify-duplicate (car errors)) ) ) )
+
+  (define-test ("Removal of nonexistent variables")
+    (collect-errors
+     (lambda ()
+       (assert-term-defs-equal (list number string)
+        (modify-terminal-definitions (list number string)
+         (list (make-terminal-modification 'number '() '(something))) ) ) )
+     (lambda (errors)
+       (assert-= 1 (length errors))
+       (assert-lang-error 'ext:term:modify:meta-var-remove-missing (car errors)) ) ) )
+
+  (define-test ("Removal of multiple nonexistent variables")
+    (collect-errors
+     (lambda ()
+       (assert-term-defs-equal (list number string)
+        (modify-terminal-definitions (list number string)
+         (list (make-terminal-modification 'number '() '(something))
+               (make-terminal-modification 'string '() '(different)) ) ) ) )
+     (lambda (errors)
+       (assert-= 2 (length errors))
+       (assert-lang-error 'ext:term:modify:meta-var-remove-missing (car errors))
+       (assert-lang-error 'ext:term:modify:meta-var-remove-missing (cadr errors)) ) ) )
+
+  (define-test ("Duplicate removal of variables")
+    (collect-errors
+     (lambda ()
+       (assert-term-defs-equal (list number0 string)
+        (modify-terminal-definitions (list number string)
+         (list (make-terminal-modification 'number '() '(n n))) ) ) )
+     (lambda (errors)
+       (assert-= 1 (length errors))
+       (assert-lang-error 'ext:term:modify:meta-var-remove-duplicate (car errors)) ) ) )
+)
+(verify-test-case! extension:terminals:mod)
+
+; - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - ;
+
+(define-test-case (extension:nonterminals:add "Nonterminal addition")
+
+  (define Pair   (make-nonterminal-definition 'Pair '(Pair) '((obj . obj))))
+  (define Pair1  (make-nonterminal-definition 'Pair '(Pair) '((car . cdr))))
+  (define Pair2  (make-nonterminal-definition 'Pair '(Pair) '((sexp . sexp))))
+  (define Number (make-nonterminal-definition 'Number '(N) '(num (/ num num))))
+  (define None   (make-nonterminal-definition 'None   '(N) '()))
+
+  (define-test ("Empty lists")
+    (assert-equal '() (append-nonterminal-definitions '() '())) )
+
+  (define-test ("Normal addition")
+    (assert-nonterm-defs-equal (list Pair Number)
+     (append-nonterminal-definitions (list Pair) (list Number))) )
+
+  (define-test ("Adding empty list")
+    (assert-nonterm-defs-equal (list Number)
+     (append-nonterminal-definitions (list Number) '())) )
+
+  (define-test ("Adding to empty list")
+    (assert-nonterm-defs-equal (list Number)
+     (append-nonterminal-definitions '() (list Number))) )
+
+  (define-test ("Does not track meta-variable duplication")
+    (assert-nonterm-defs-equal (list Number None)
+     (append-nonterminal-definitions (list Number) (list None))) )
+
+  (define-test ("Allows to add multiple of the same name")
+    (assert-nonterm-defs-equal (list Number Pair Pair1)
+     (append-nonterminal-definitions (list Number) (list Pair Pair1))) )
+
+  (define-test ("Allows to add existing name")
+    (assert-nonterm-defs-equal (list Number Pair Pair1)
+     (append-nonterminal-definitions (list Number Pair) (list Pair1))) )
+
+  (define-test ("Allows to add multiple of the same existing name")
+    (assert-nonterm-defs-equal (list Number Pair Pair1 Pair2)
+     (append-nonterminal-definitions (list Number Pair) (list Pair1 Pair2))) )
+
+  (define-test ("Does not fail on preexisting duplicates")
+    (assert-nonterm-defs-equal (list Pair1 Pair2 Pair)
+     (append-nonterminal-definitions (list Pair1 Pair2) (list Pair))) )
+)
+(verify-test-case! extension:nonterminals:add)
+
+; - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - ;
+
+(define-test-case (extension:nonterminals:rem "Nonterminal removal")
+
+  (define Pair   (make-nonterminal-definition 'Pair   '(Pair) '((obj . obj))))
+  (define Number (make-nonterminal-definition 'Number '(N) '(num (/ num num))))
+  (define None   (make-nonterminal-definition 'None   '(N) '()))
+
+  (define-test ("Empty lists")
+    (assert-equal '() (remove-nonterminal-definitions '() '())) )
+
+  (define-test ("Normal removal")
+    (assert-nonterm-defs-equal (list Number)
+     (remove-nonterminal-definitions (list Number Pair) '(Pair))) )
+
+  (define-test ("Removing an empty list")
+    (assert-nonterm-defs-equal (list Number Pair)
+     (remove-nonterminal-definitions (list Number Pair) '())) )
+
+  (define-test ("Removing everything")
+    (assert-nonterm-defs-equal '()
+     (remove-nonterminal-definitions (list Number Pair None) '(Pair Number None))) )
+
+  (define-test ("Removal of nonexistent definitions")
+    (collect-errors
+     (lambda ()
+       (assert-nonterm-defs-equal (list Number Pair)
+        (remove-nonterminal-definitions (list Number Pair) '(other)) ) )
+     (lambda (errors)
+       (assert-= 1 (length errors))
+       (assert-lang-error 'ext:nonterm:remove-missing (car errors)) ) ) )
+
+  (define-test ("Removal of multiple nonexistent definitions")
+    (collect-errors
+     (lambda ()
+       (assert-nonterm-defs-equal (list Number Pair)
+        (remove-nonterminal-definitions (list Number Pair) '(Other Another)) ) )
+     (lambda (errors)
+       (assert-= 1 (length errors))
+       (assert-lang-error 'ext:nonterm:remove-missing (car errors)) ) ) )
+
+  (define-test ("Duplicate removals")
+    (collect-errors
+     (lambda ()
+       (assert-nonterm-defs-equal (list Pair)
+        (remove-nonterminal-definitions (list Number Pair) '(Number Number)) ) )
+     (lambda (errors)
+       (assert-= 1 (length errors))
+       (assert-lang-error 'ext:nonterm:remove-duplicate (car errors)) ) ) )
+
+  (define-test ("Duplicate removal of nonexistent definitions")
+    (collect-errors
+     (lambda ()
+       (assert-nonterm-defs-equal (list Number)
+        (remove-nonterminal-definitions (list Number Pair) '(Other Other Pair)) ) )
+     (lambda (errors)
+       (assert-= 2 (length errors))
+       (assert-lang-error 'ext:nonterm:remove-duplicate (car errors))
+       (assert-lang-error 'ext:nonterm:remove-missing (cadr errors)) ) ) )
+)
+(verify-test-case! extension:nonterminals:rem)
+
+; - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - ;
+
+(define-test-case (extension:nonterminals:mod-meta-vars "Nonterminal modification (meta-variables)")
+
+  (define Number (make-nonterminal-definition 'Number '(N) '()))
+  (define Void   (make-nonterminal-definition 'Void   '(V) '()))
+
+  (define Number* (make-nonterminal-definition 'Number '(N M)  '()))
+  (define Void*   (make-nonterminal-definition 'Void   '(Void) '()))
+
+  (define Number0 (make-nonterminal-definition 'Number '()      '()))
+  (define Number2 (make-nonterminal-definition 'Number '(N N)   '()))
+  (define Number3 (make-nonterminal-definition 'Number '(N N N) '()))
+
+  (define-test ("Empty lists")
+    (assert-equal '() (modify-nonterminal-definitions '() '() '())) )
+
+  (define-test ("Normal modification (adding variables)")
+    (assert-nonterm-defs-equal (list Number* Void)
+     (modify-nonterminal-definitions '() (list Number Void)
+      (list (make-nonterminal-modification 'Number '(M) '() '() '())) ) ) )
+
+  (define-test ("Normal modification (removing variables)")
+    (assert-nonterm-defs-equal (list Number)
+     (modify-nonterminal-definitions '() (list Number*)
+      (list (make-nonterminal-modification 'Number '() '(M) '() '())) ) ) )
+
+  (define-test ("Normal modification (replacing variables)")
+    (assert-nonterm-defs-equal (list Number Void*)
+     (modify-nonterminal-definitions '() (list Number Void)
+      (list (make-nonterminal-modification 'Void '(Void) '(V) '() '())) ) ) )
+
+  (define-test ("Not modifying anything (empty list)")
+    (assert-nonterm-defs-equal (list Number Void)
+     (modify-nonterminal-definitions '() (list Number Void) '())) )
+
+  (define-test ("Not modifying anything (with noops)")
+    (assert-nonterm-defs-equal (list Number Void)
+     (modify-nonterminal-definitions '() (list Number Void)
+      (list (make-nonterminal-modification 'Number '() '() '() '())
+            (make-nonterminal-modification 'Void   '() '() '() '()) ) ) ) )
+
+  (define-test ("Allows to add duplicate variables")
+    (assert-nonterm-defs-equal (list Number2)
+     (modify-nonterminal-definitions '() (list Number)
+      (list (make-nonterminal-modification 'Number '(N) '() '() '())) ) ) )
+
+  (define-test ("Allows to add duplicate variables (2)")
+    (assert-nonterm-defs-equal (list Number3)
+     (modify-nonterminal-definitions '() (list Number)
+      (list (make-nonterminal-modification 'Number '(N N) '() '() '())) ) ) )
+
+  (define-test ("Allows to remove all variables")
+    (assert-nonterm-defs-equal (list Number0)
+     (modify-nonterminal-definitions '() (list Number)
+      (list (make-nonterminal-modification 'Number '() '(N) '() '())) ) ) )
+
+  (define-test ("Allows to remove and re-add a variable")
+    (assert-nonterm-defs-equal (list Void)
+     (modify-nonterminal-definitions '() (list Void)
+      (list (make-nonterminal-modification 'Void '(V) '(V) '() '())) ) ) )
+
+  (define-test ("Modification of nonexistent definition")
+    (collect-errors
+     (lambda ()
+       (assert-nonterm-defs-equal (list Number Void)
+        (modify-nonterminal-definitions '() (list Number Void)
+         (list (make-nonterminal-modification 'String '(Str) '(S) '() '())) ) ) )
+     (lambda (errors)
+       (assert-= 1 (length errors))
+       (assert-lang-error 'ext:nonterm:modify-missing (car errors)) ) ) )
+
+  (define-test ("Duplicate modification")
+    (collect-errors
+     (lambda ()
+       ; no assumptions about what we get as result in this case
+       (modify-nonterminal-definitions '() (list Number)
+        (list (make-nonterminal-modification 'Number '(Num) '() '() '())
+              (make-nonterminal-modification 'Number '() '(N) '() '()) ) ) )
+     (lambda (errors)
+       (assert-= 1 (length errors))
+       (assert-lang-error 'ext:nonterm:modify-duplicate (car errors)) ) ) )
+
+  (define-test ("Removal of nonexistent variables")
+    (collect-errors
+     (lambda ()
+       (assert-nonterm-defs-equal (list Number Void)
+        (modify-nonterminal-definitions '() (list Number Void)
+         (list (make-nonterminal-modification 'Number '() '(something) '() '())) ) ) )
+     (lambda (errors)
+       (assert-= 1 (length errors))
+       (assert-lang-error 'ext:nonterm:modify:meta-var-remove-missing (car errors)) ) ) )
+
+  (define-test ("Removal of multiple nonexistent variables")
+    (collect-errors
+     (lambda ()
+       (assert-nonterm-defs-equal (list Number Void)
+        (modify-nonterminal-definitions '() (list Number Void)
+         (list (make-nonterminal-modification 'Number '() '(something) '() '())
+               (make-nonterminal-modification 'Void '() '(different) '() '()) ) ) ) )
+     (lambda (errors)
+       (assert-= 2 (length errors))
+       (assert-lang-error 'ext:nonterm:modify:meta-var-remove-missing (car errors))
+       (assert-lang-error 'ext:nonterm:modify:meta-var-remove-missing (cadr errors)) ) ) )
+
+  (define-test ("Duplicate removal of variables")
+    (collect-errors
+     (lambda ()
+       (assert-nonterm-defs-equal (list Number0 Void)
+        (modify-nonterminal-definitions '() (list Number Void)
+         (list (make-nonterminal-modification 'Number '() '(N N) '() '())) ) ) )
+     (lambda (errors)
+       (assert-= 1 (length errors))
+       (assert-lang-error 'ext:nonterm:modify:meta-var-remove-duplicate (car errors)) ) ) )
+)
+(verify-test-case! extension:nonterminals:mod-meta-vars)
+
+; - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - ;
+
+(define-test-case (extension:nonterminals:mod-productions "Nonterminal modification (productions)")
+
+  (define integer (make-terminal-definition 'integer integer? '(i j k)))
+  (define string  (make-terminal-definition 'string  string?  '(s)))
+
+  (define Number (make-nonterminal-definition 'Number '(N) '(i (i i) (/ i i))))
+  (define Void   (make-nonterminal-definition 'Void   '(V) '(())))
+  (define Object (make-nonterminal-definition 'Object '(O) '(N V)))
+
+  (define Number1 (make-nonterminal-definition 'Number '(N) '(i (i i) (/ i i) (k k k))))
+  (define Number2 (make-nonterminal-definition 'Number '(N) '(i (/ i i))))
+  (define Number3 (make-nonterminal-definition 'Number '(N) '(i (i i) (/ i i) (j j))))
+  (define Number4 (make-nonterminal-definition 'Number '(N) '(i (i i) (/ i i) (i i))))
+
+  (define Void0   (make-nonterminal-definition 'Void   '(V) '()))
+  (define Void1   (make-nonterminal-definition 'Void   '(V) '(V)))
+
+  (define Object1 (make-nonterminal-definition 'Object '(O) '(N V s)))
+  (define Object2 (make-nonterminal-definition 'Object '(O) '(N V s (i) (j) (k))))
+
+  (define-test ("Empty lists")
+    (assert-equal '() (modify-nonterminal-definitions '() '() '())) )
+
+  (define-test ("Normal modification (adding productions)")
+    (assert-nonterm-defs-equal (list Number1 Void)
+     (modify-nonterminal-definitions (list integer string) (list Number Void)
+      (list (make-nonterminal-modification 'Number '() '() '((k k k)) '())) ) ) )
+
+  (define-test ("Normal modification (removing productions)")
+    (assert-nonterm-defs-equal (list Number2)
+     (modify-nonterminal-definitions (list integer string) (list Number)
+      (list (make-nonterminal-modification 'Number '() '() '() '((i i)))) ) ) )
+
+  (define-test ("Normal modification (replacing productions)")
+    (assert-nonterm-defs-equal (list Number Void1)
+     (modify-nonterminal-definitions (list integer string) (list Number Void)
+      (list (make-nonterminal-modification 'Void '() '() '(V) '(()))) ) ) )
+
+  (define-test ("Not modifying anything (empty list)")
+    (assert-nonterm-defs-equal (list Number Void)
+     (modify-nonterminal-definitions (list integer string) (list Number Void) '())) )
+
+  (define-test ("Not modifying anything (with noops)")
+    (assert-nonterm-defs-equal (list Number Void)
+     (modify-nonterminal-definitions (list integer string) (list Number Void)
+      (list (make-nonterminal-modification 'Number '() '() '() '())
+            (make-nonterminal-modification 'Void   '() '() '() '()) ) ) ) )
+
+  (define-test ("Allows to add duplicate productions")
+    (assert-nonterm-defs-equal (list Number4)
+     (modify-nonterminal-definitions (list integer string) (list Number)
+      (list (make-nonterminal-modification 'Number '() '() '((i i)) '())) ) ) )
+
+  (define-test ("Allows to add duplicate productions (2)")
+    (assert-nonterm-defs-equal (list Number3)
+     (modify-nonterminal-definitions (list integer string) (list Number)
+      (list (make-nonterminal-modification 'Number '() '() '((j j)) '())) ) ) )
+
+  (define-test ("Allows to add duplicate productions (3)")
+    (assert-nonterm-defs-equal (list Object2)
+     (modify-nonterminal-definitions (list integer string) (list Object)
+      (list (make-nonterminal-modification 'Object '() '() '(s (i) (j) (k)) '())) ) ) )
+
+  (define-test ("Removes by semantic unification")
+    (assert-nonterm-defs-equal (list Number2)
+     (modify-nonterminal-definitions (list integer string) (list Number)
+      (list (make-nonterminal-modification 'Number '() '() '() '((k k)))) ) ) )
+
+  (define-test ("Allows to remove all productions")
+    (assert-nonterm-defs-equal (list Void0)
+     (modify-nonterminal-definitions (list integer string) (list Void)
+      (list (make-nonterminal-modification 'Void '() '() '() '(()))) ) ) )
+
+  (define-test ("Allows to remove and re-add a production")
+    (assert-nonterm-defs-equal (list Void)
+     (modify-nonterminal-definitions (list integer string) (list Void)
+      (list (make-nonterminal-modification 'Void '() '() '(()) '(()))) ) ) )
+
+  (define-test ("Allows to remove and re-add a production (2)")
+    (assert-nonterm-defs-equal (list Number4)
+     (modify-nonterminal-definitions (list integer string) (list Number3)
+      (list (make-nonterminal-modification 'Number '() '() '((i i)) '((j j)))) ) ) )
+
+  (define-test ("Modification of nonexistent definition")
+    (collect-errors
+     (lambda ()
+       (assert-nonterm-defs-equal (list Number Void)
+        (modify-nonterminal-definitions (list integer string) (list Number Void)
+         (list (make-nonterminal-modification 'String '() '() '(s) '((s s)))) ) ) )
+     (lambda (errors)
+       (assert-= 1 (length errors))
+       (assert-lang-error 'ext:nonterm:modify-missing (car errors)) ) ) )
+
+  (define-test ("Duplicate modification")
+    (collect-errors
+     (lambda ()
+       ; no assumptions about what we get as result in this case
+       (modify-nonterminal-definitions (list integer string) (list Number)
+        (list (make-nonterminal-modification 'Number '() '() '((j j)) '())
+              (make-nonterminal-modification 'Number '() '() '() '((k k))) ) ) )
+     (lambda (errors)
+       (assert-= 1 (length errors))
+       (assert-lang-error 'ext:nonterm:modify-duplicate (car errors)) ) ) )
+
+  (define-test ("Removal of nonexistent productions")
+    (collect-errors
+     (lambda ()
+       (assert-nonterm-defs-equal (list Number Void)
+        (modify-nonterminal-definitions (list integer string) (list Number Void)
+         (list (make-nonterminal-modification 'Number '() '() '() '(something))) ) ) )
+     (lambda (errors)
+       (assert-= 1 (length errors))
+       (assert-lang-error 'ext:nonterm:modify:production-remove-missing (car errors)) ) ) )
+
+  (define-test ("Removal of nonexistent productions (as literals)")
+    (collect-errors
+     (lambda ()
+       (assert-nonterm-defs-equal (list Number Void)
+        (modify-nonterminal-definitions (list string) (list Number Void)
+         (list (make-nonterminal-modification 'Number '() '() '() '((j j)))) ) ) )
+     (lambda (errors)
+       (assert-= 1 (length errors))
+       (assert-lang-error 'ext:nonterm:modify:production-remove-missing (car errors)) ) ) )
+
+  (define-test ("Removal of multiple nonexistent productions")
+    (collect-errors
+     (lambda ()
+       (assert-nonterm-defs-equal (list Number Void)
+        (modify-nonterminal-definitions (list integer string) (list Number Void)
+         (list (make-nonterminal-modification 'Number '() '() '() '(something))
+               (make-nonterminal-modification 'Void   '() '() '() '(different)) ) ) ) )
+     (lambda (errors)
+       (assert-= 2 (length errors))
+       (assert-lang-error 'ext:nonterm:modify:production-remove-missing (car errors))
+       (assert-lang-error 'ext:nonterm:modify:production-remove-missing (cadr errors)) ) ) )
+
+  (define-test ("Duplicate removal of production")
+    (collect-errors
+     (lambda ()
+       (assert-nonterm-defs-equal (list Number2 Void)
+        (modify-nonterminal-definitions (list integer string) (list Number Void)
+         (list (make-nonterminal-modification 'Number '() '() '() '((i i) (i i)))) ) ) )
+     (lambda (errors)
+       (assert-= 1 (length errors))
+       (assert-lang-error 'ext:nonterm:modify:production-remove-duplicate (car errors)) ) ) )
+
+  (define-test ("Duplicate removal of production (2)")
+    (collect-errors
+     (lambda ()
+       (assert-nonterm-defs-equal (list Number2 Void)
+        (modify-nonterminal-definitions (list integer string) (list Number Void)
+         (list (make-nonterminal-modification 'Number '() '() '() '((i i) (j j)))) ) ) )
+     (lambda (errors)
+       (assert-= 1 (length errors))
+       (assert-lang-error 'ext:nonterm:modify:production-remove-duplicate (car errors)) ) ) )
+)
+(verify-test-case! extension:nonterminals:mod-productions)

--- a/np/lang/descriptions/test/test-syntax.ss
+++ b/np/lang/descriptions/test/test-syntax.ss
@@ -1,7 +1,7 @@
 (import (scheme base)
         (only (srfi 1) every)
+        (np lang descriptions definitions)
         (np lang descriptions errors)
-        (np lang descriptions types)
         (np lang descriptions syntax)
         (np lang descriptions test utils)
         (te base)

--- a/np/lang/descriptions/test/test-syntax.ss
+++ b/np/lang/descriptions/test/test-syntax.ss
@@ -1,5 +1,6 @@
 (import (scheme base)
         (only (srfi 1) every)
+        (np lang descriptions errors)
         (np lang descriptions types)
         (np lang descriptions syntax)
         (np lang descriptions test-utils)

--- a/np/lang/descriptions/test/test-syntax.ss
+++ b/np/lang/descriptions/test/test-syntax.ss
@@ -3,7 +3,7 @@
         (np lang descriptions errors)
         (np lang descriptions types)
         (np lang descriptions syntax)
-        (np lang descriptions test-utils)
+        (np lang descriptions test utils)
         (te base)
         (te conditions assertions)
         (te conditions define-assertion)

--- a/np/lang/descriptions/test/test-unification.ss
+++ b/np/lang/descriptions/test/test-unification.ss
@@ -1,5 +1,6 @@
 (import (scheme base)
         (np lang descriptions unification)
+        (np lang descriptions definitions)
         (te base)
         (te conditions assertions)
         (te utils verify-test-case))
@@ -37,3 +38,55 @@
     (assert-eq after (trim-meta-var-name before)) )
 )
 (verify-test-case! unification:meta-var-names)
+
+; - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - ;
+
+(define-test-case (unification:productions "Production comparison")
+
+  (define mapping (make-meta-var-mapping
+   (list (make-terminal-definition 'number number? '(n m))
+         (make-terminal-definition 'string string? '(s str)) )
+   (list (make-nonterminal-definition 'Number '(Num Number) '())
+         (make-nonterminal-definition 'NamedNumber '(Name NamedNumber) '()) ) ))
+
+  (define-test ("Normal case")
+    (assert-true
+     (productions-equal? mapping '(Num n s) '(Num n s)) ) )
+
+  (define-test ("Empty lists are equal")
+    (assert-true
+     (productions-equal? mapping '() '()) ) )
+
+  (define-test ("Can use any of meta-vars")
+    (assert-true
+     (productions-equal? mapping '(Num n s) '(Number m str)) ) )
+
+  (define-test ("Suffixes do not matter for meta-vars")
+    (assert-true
+     (productions-equal? mapping '(Num* n+ s9) '(Number000 m? str???*)) ) )
+
+  (define-test ("Can handle literals")
+    (assert-true
+     (productions-equal? mapping '(/ Num Num) '(/ Number Number)) ) )
+
+  (define-test ("Can handle maybe")
+    (assert-true
+     (productions-equal? mapping '(+ (maybe Num) Num) '(+ (maybe Number) Number)) ) )
+
+  (define-test ("Can handle repetitions")
+    (assert-true
+     (productions-equal? mapping '(n ... s !..) '(m ... str !..)) ) )
+
+  (define-test ("Suffixes do matter for literals")
+    (assert-false
+     (productions-equal? mapping '(e n n s) '(e* n* n* s*)) ) )
+
+  (define-test ("Literals do not match meta-vars")
+    (assert-false
+     (productions-equal? mapping 'n 'N) ) )
+
+  (define-test ("Different entities do not match")
+    (assert-false
+     (productions-equal? mapping 'Num 'n) ) )
+)
+(verify-test-case! unification:productions)

--- a/np/lang/descriptions/test/test-unification.ss
+++ b/np/lang/descriptions/test/test-unification.ss
@@ -1,0 +1,39 @@
+(import (scheme base)
+        (np lang descriptions unification)
+        (te base)
+        (te conditions assertions)
+        (te utils verify-test-case))
+
+; - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - ;
+
+(define-test-case (unification:meta-var-names "Trimming of meta variable names")
+
+  (define-test ("Smoke test")
+    (assert-eq 'test (trim-meta-var-name 'test)) )
+
+  (define-test ("Strips arbitrary decimal number suffixes" before after)
+    #('((foo123 foo) (bar5 bar) (zog9999 zog)))
+    (assert-eq after (trim-meta-var-name before)) )
+
+  (define-test ("Strips arbitrary combinations of special symbols" before after)
+    #('((zush*** zush) (wee+ wee) (omg? omg) (aaaaa^^^^ aaaaa)
+        (boom*?*+*?^*^^^ boom) (a+*?+*+*+?*?+*+*+++*++**++ a)))
+    (assert-eq after (trim-meta-var-name before)) )
+
+  (define-test ("Strips arbitrary decimal numbers followed by arbitrary combinations of special symbols" before after)
+    #('((a1*^^ a) (booo0+++ booo) (woo1231**??^ woo)))
+    (assert-eq after (trim-meta-var-name before)) )
+
+  (define-test ("Strips only the last combinations")
+    (assert-eq 'check123*+* (trim-meta-var-name 'check123*+*123))
+    (assert-eq 'check*+*    (trim-meta-var-name 'check*+*123*+*)) )
+
+  (define-test ("Clears entirely special symbols" name)
+    #('((+) (?) (^) (*) (+++++***) (*?+^*?+^) (|123+?*|) (|1|) (|1?|)))
+    (assert-eq '|| (trim-meta-var-name name)) )
+
+  (define-test ("Tricky cases" before after)
+    #('((|+123| +) (*1* *) (*?1 *?) (|| ||)))
+    (assert-eq after (trim-meta-var-name before)) )
+)
+(verify-test-case! unification:meta-var-names)

--- a/np/lang/descriptions/test/utils.sld
+++ b/np/lang/descriptions/test/utils.sld
@@ -5,8 +5,8 @@
   (export assert-lang-error)
 
   (import (scheme base)
+          (np lang descriptions definitions)
           (np lang descriptions errors)
-          (np lang descriptions types)
           (te conditions define-assertion))
 
   (begin

--- a/np/lang/descriptions/test/utils.sld
+++ b/np/lang/descriptions/test/utils.sld
@@ -1,4 +1,4 @@
-(define-library (np lang descriptions test-utils)
+(define-library (np lang descriptions test utils)
   ;;;
   ;;; Utilities for description processing testing.
   ;;;

--- a/np/lang/descriptions/types.sld
+++ b/np/lang/descriptions/types.sld
@@ -2,28 +2,28 @@
   ;;;
   ;;; Types used in processing of language definitions and descriptions
   ;;;
-  (export terminal-definition terminal-definition?
+  (export terminal-definition?
           make-terminal-definition
           with-terminal-definition
           terminal-name
           terminal-predicate
           terminal-meta-variables
 
-          terminal-modification terminal-modification?
+          terminal-modification?
           make-terminal-modification
           with-terminal-modification
           modified-terminal-name
           modified-terminal-added-meta-variables
           modified-terminal-removed-meta-variables
 
-          nonterminal-definition nonterminal-definition?
+          nonterminal-definition?
           make-nonterminal-definition
           with-nonterminal-definition
           nonterminal-name
           nonterminal-meta-variables
           nonterminal-production-definitions
 
-          nonterminal-modification nonterminal-modification?
+          nonterminal-modification?
           make-nonterminal-modification
           with-nonterminal-modification
           modified-nonterminal-name

--- a/np/lang/descriptions/types.sld
+++ b/np/lang/descriptions/types.sld
@@ -30,12 +30,7 @@
           modified-nonterminal-added-meta-variables
           modified-nonterminal-removed-meta-variables
           modified-nonterminal-added-production-definitions
-          modified-nonterminal-removed-production-definitions
-
-          lang-error lang-error?
-          lang-error-kind
-          lang-error-object
-          lang-error-causes)
+          modified-nonterminal-removed-production-definitions)
 
   (import (scheme base))
 
@@ -109,19 +104,5 @@
                (added-production-definitions   (modified-nonterminal-added-production-definitions   nonterminal))
                (removed-production-definitions (modified-nonterminal-removed-production-definitions nonterminal)))
            expr ...)) ) )
-
-    ;;;
-    ;;; Error report object
-    ;;;
-
-    (define-record-type %lang-error
-      (make-lang-error kind object causes)
-      lang-error?
-      (kind   lang-error-kind)
-      (object lang-error-object)
-      (causes lang-error-causes) )
-
-    (define (lang-error kind object . causes)
-      (make-lang-error kind object causes) )
 
 ) )

--- a/np/lang/descriptions/unification.sld
+++ b/np/lang/descriptions/unification.sld
@@ -2,9 +2,13 @@
   ;;;
   ;;; Term normalization and unification
   ;;;
-  (export trim-meta-var-name)
+  (export trim-meta-var-name
+          make-meta-var-mapping
+          productions-equal?)
 
-  (import (scheme base))
+  (import (scheme base)
+          (srfi 69) ; hash tables
+          (np lang descriptions definitions))
 
   (begin
     ;;;
@@ -38,4 +42,42 @@
 
          (scan-special (- (string-length name) 1)) ) ) )
 
+    ;;;
+    ;;; Productions
+    ;;;
+
+    (define (make-meta-var-mapping terminals nonterminals)
+      (let ((hash (make-hash-table eq? hash-by-identity)))
+        (for-each
+          (lambda (terminal)
+            (for-each
+              (lambda (meta-var) (hash-table-set! hash meta-var terminal))
+              (terminal-meta-variables terminal) ) )
+          terminals )
+        (for-each
+          (lambda (nonterminal)
+            (for-each
+              (lambda (meta-var) (hash-table-set! hash meta-var nonterminal))
+              (nonterminal-meta-variables nonterminal) ) )
+          nonterminals )
+        hash ) )
+
+    (define (productions-equal? mapping p1 p2)
+      (cond ((and (null? p1) (null? p2)) #t)
+            ((and (symbol? p1) (symbol? p2))
+             (symbols-equal? mapping p1 p2) )
+            ((and (pair? p1) (pair? p2))
+             (and (productions-equal? mapping (car p1) (car p2))
+                  (productions-equal? mapping (cdr p1) (cdr p2)) ) )
+            (else #f) ) )
+
+    (define (symbols-equal? mapping s1 s2)
+      (if (eq? s1 s2) ; If symbols are equal
+          #t ; they are either equal literals, or obviously equal meta-variables
+          (let ((e1 (hash-table-ref/default mapping (trim-meta-var-name s1) #f))
+                (e2 (hash-table-ref/default mapping (trim-meta-var-name s2) #f)))
+            (if (and e1 e2) ; If both symbols denote meta-variables
+                (eq? e1 e2) ; they must refer to the same entity.
+                #f ) ) ) )  ; Otherwise, one of them is literal and the other
+                            ; one is a meta-variable or some different literal
 ) )

--- a/np/lang/descriptions/unification.sld
+++ b/np/lang/descriptions/unification.sld
@@ -1,0 +1,41 @@
+(define-library (np lang descriptions unification)
+  ;;;
+  ;;; Term normalization and unification
+  ;;;
+  (export trim-meta-var-name)
+
+  (import (scheme base))
+
+  (begin
+    ;;;
+    ;;; Name trimming
+    ;;;
+
+    (define (trim-meta-var-name name)
+      (string->symbol
+       (let ((name (symbol->string name)))
+         ;
+         ; s/^(.*?)[0-9]*[?*+^]*$/\1/
+         ;
+         (define (digit? c)
+           (char<=? #\0 c #\9) )
+
+         (define (special? c)
+           (or (char=? #\? c) (char=? #\* c)
+               (char=? #\+ c) (char=? #\^ c) ) )
+
+         (define (scan-special i)
+           (if (< i 0) ""
+               (if (special? (string-ref name i))
+                   (scan-special (- i 1))
+                   (scan-digits i) ) ) )
+
+         (define (scan-digits i)
+           (if (< i 0) ""
+               (if (digit? (string-ref name i))
+                   (scan-digits (- i 1))
+                   (substring name 0 (+ i 1)) ) ) )
+
+         (scan-special (- (string-length name) 1)) ) ) )
+
+) )

--- a/np/lang/macros/codegen.sld
+++ b/np/lang/macros/codegen.sld
@@ -19,8 +19,8 @@
           $generate-extension-nonterminal-predicate-definitions)
 
   (import (scheme base)
+          (np lang descriptions definitions)
           (np lang descriptions language)
-          (np lang descriptions types)
           (sr ck)
           (sr ck kernel)
           (sr ck lists)

--- a/np/lang/macros/test/codegen/test-codegen-nonterminals.ss
+++ b/np/lang/macros/test/codegen/test-codegen-nonterminals.ss
@@ -1,7 +1,7 @@
 (import (scheme base)
         (only (srfi 1) every first second)
         (np lang macros codegen)
-        (np lang descriptions types)
+        (np lang descriptions definitions)
         (sr ck)
         (sr ck kernel)
         (te base)

--- a/np/lang/macros/test/codegen/test-codegen-terminals.ss
+++ b/np/lang/macros/test/codegen/test-codegen-terminals.ss
@@ -1,7 +1,7 @@
 (import (scheme base)
         (only (srfi 1) every first second)
         (np lang macros codegen)
-        (np lang descriptions types)
+        (np lang descriptions definitions)
         (sr ck)
         (sr ck kernel)
         (te base)

--- a/np/lang/macros/test/codegen/test-codegen-toplevel.ss
+++ b/np/lang/macros/test/codegen/test-codegen-toplevel.ss
@@ -1,6 +1,6 @@
 (import (scheme base)
         (np lang macros codegen)
-        (np lang descriptions types)
+        (np lang descriptions definitions)
         (sr ck)
         (sr ck kernel)
         (te base)

--- a/np/lang/macros/test/define-language/test-define-language-errors.ss
+++ b/np/lang/macros/test/define-language/test-define-language-errors.ss
@@ -1,7 +1,7 @@
 (import (scheme base)
         (np lang macros define-language)
         (np lang descriptions language)
-        (np lang macros test-utils)
+        (np lang macros test utils)
         (sr ck)
         (sr ck kernel)
         (te base)

--- a/np/lang/macros/test/partitioning/nonterminals/test-errors-extension-addition.ss
+++ b/np/lang/macros/test/partitioning/nonterminals/test-errors-extension-addition.ss
@@ -1,6 +1,6 @@
 (import (scheme base)
         (np lang macros partitioning)
-        (np lang macros test-utils)
+        (np lang macros test utils)
         (sr ck)
         (sr ck kernel)
         (te base)

--- a/np/lang/macros/test/partitioning/nonterminals/test-errors-extension-modification.ss
+++ b/np/lang/macros/test/partitioning/nonterminals/test-errors-extension-modification.ss
@@ -1,6 +1,6 @@
 (import (scheme base)
         (np lang macros partitioning)
-        (np lang macros test-utils)
+        (np lang macros test utils)
         (sr ck)
         (sr ck kernel)
         (te base)

--- a/np/lang/macros/test/partitioning/nonterminals/test-errors-extension-removal.ss
+++ b/np/lang/macros/test/partitioning/nonterminals/test-errors-extension-removal.ss
@@ -1,6 +1,6 @@
 (import (scheme base)
         (np lang macros partitioning)
-        (np lang macros test-utils)
+        (np lang macros test utils)
         (sr ck)
         (sr ck kernel)
         (te base)

--- a/np/lang/macros/test/partitioning/nonterminals/test-errors-extension.ss
+++ b/np/lang/macros/test/partitioning/nonterminals/test-errors-extension.ss
@@ -1,6 +1,6 @@
 (import (scheme base)
         (np lang macros partitioning)
-        (np lang macros test-utils)
+        (np lang macros test utils)
         (sr ck)
         (sr ck kernel)
         (te base)

--- a/np/lang/macros/test/partitioning/nonterminals/test-errors-standalone.ss
+++ b/np/lang/macros/test/partitioning/nonterminals/test-errors-standalone.ss
@@ -1,6 +1,6 @@
 (import (scheme base)
         (np lang macros partitioning)
-        (np lang macros test-utils)
+        (np lang macros test utils)
         (sr ck)
         (sr ck kernel)
         (te base)

--- a/np/lang/macros/test/partitioning/terminals/test-errors-extension-addition.ss
+++ b/np/lang/macros/test/partitioning/terminals/test-errors-extension-addition.ss
@@ -1,6 +1,6 @@
 (import (scheme base)
         (np lang macros partitioning)
-        (np lang macros test-utils)
+        (np lang macros test utils)
         (sr ck)
         (sr ck kernel)
         (te base)

--- a/np/lang/macros/test/partitioning/terminals/test-errors-extension-modification.ss
+++ b/np/lang/macros/test/partitioning/terminals/test-errors-extension-modification.ss
@@ -1,6 +1,6 @@
 (import (scheme base)
         (np lang macros partitioning)
-        (np lang macros test-utils)
+        (np lang macros test utils)
         (sr ck)
         (sr ck kernel)
         (te base)

--- a/np/lang/macros/test/partitioning/terminals/test-errors-extension-removal.ss
+++ b/np/lang/macros/test/partitioning/terminals/test-errors-extension-removal.ss
@@ -1,6 +1,6 @@
 (import (scheme base)
         (np lang macros partitioning)
-        (np lang macros test-utils)
+        (np lang macros test utils)
         (sr ck)
         (sr ck kernel)
         (te base)

--- a/np/lang/macros/test/partitioning/terminals/test-errors-extension.ss
+++ b/np/lang/macros/test/partitioning/terminals/test-errors-extension.ss
@@ -1,6 +1,6 @@
 (import (scheme base)
         (np lang macros partitioning)
-        (np lang macros test-utils)
+        (np lang macros test utils)
         (sr ck)
         (sr ck kernel)
         (te base)

--- a/np/lang/macros/test/partitioning/terminals/test-errors-standalone.ss
+++ b/np/lang/macros/test/partitioning/terminals/test-errors-standalone.ss
@@ -1,6 +1,6 @@
 (import (scheme base)
         (np lang macros partitioning)
-        (np lang macros test-utils)
+        (np lang macros test utils)
         (sr ck)
         (sr ck kernel)
         (te base)

--- a/np/lang/macros/test/partitioning/toplevel/test-errors-extends.ss
+++ b/np/lang/macros/test/partitioning/toplevel/test-errors-extends.ss
@@ -1,6 +1,6 @@
 (import (scheme base)
         (np lang macros partitioning)
-        (np lang macros test-utils)
+        (np lang macros test utils)
         (sr ck)
         (sr ck kernel)
         (te base)

--- a/np/lang/macros/test/partitioning/toplevel/test-errors-parser.ss
+++ b/np/lang/macros/test/partitioning/toplevel/test-errors-parser.ss
@@ -1,6 +1,6 @@
 (import (scheme base)
         (np lang macros partitioning)
-        (np lang macros test-utils)
+        (np lang macros test utils)
         (sr ck)
         (sr ck kernel)
         (te base)

--- a/np/lang/macros/test/partitioning/toplevel/test-errors-predicate.ss
+++ b/np/lang/macros/test/partitioning/toplevel/test-errors-predicate.ss
@@ -1,6 +1,6 @@
 (import (scheme base)
         (np lang macros partitioning)
-        (np lang macros test-utils)
+        (np lang macros test utils)
         (sr ck)
         (sr ck kernel)
         (te base)

--- a/np/lang/macros/test/partitioning/toplevel/test-errors-terminals.ss
+++ b/np/lang/macros/test/partitioning/toplevel/test-errors-terminals.ss
@@ -1,6 +1,6 @@
 (import (scheme base)
         (np lang macros partitioning)
-        (np lang macros test-utils)
+        (np lang macros test utils)
         (sr ck)
         (sr ck kernel)
         (te base)

--- a/np/lang/macros/test/partitioning/toplevel/test-errors-toplevel.ss
+++ b/np/lang/macros/test/partitioning/toplevel/test-errors-toplevel.ss
@@ -1,6 +1,6 @@
 (import (scheme base)
         (np lang macros partitioning)
-        (np lang macros test-utils)
+        (np lang macros test utils)
         (sr ck)
         (sr ck kernel)
         (te base)

--- a/np/lang/macros/test/partitioning/toplevel/test-errors-unparser.ss
+++ b/np/lang/macros/test/partitioning/toplevel/test-errors-unparser.ss
@@ -1,6 +1,6 @@
 (import (scheme base)
         (np lang macros partitioning)
-        (np lang macros test-utils)
+        (np lang macros test utils)
         (sr ck)
         (sr ck kernel)
         (te base)

--- a/np/lang/macros/test/utils.sld
+++ b/np/lang/macros/test/utils.sld
@@ -1,4 +1,4 @@
-(define-library (np lang macros test-utils)
+(define-library (np lang macros test utils)
   ;;;
   ;;; Utilities for macroexpansion testing.
   ;;;


### PR DESCRIPTION
This pull request implements procedures performing language extension and some unification utilities. It also includes some code cleanup.

Cleanup:
- Move lang-error into a separate library
- Move test-utils into test directory
- Do not export record definition objects
- Rename (np lang descriptions {types => definitions})

Unification:
- Meta-variable suffix trimmer
- Production equality comparison

Extension:
- Processing language extensions

Partial fulfillment of issue #1
