### PR TITLE
Drop support of short terminal form

### DIFF
--- a/np/lang/macros/README.md
+++ b/np/lang/macros/README.md
@@ -382,13 +382,11 @@ _**Syntax violations**_:
 
 Referenced as: _standalone-terminal_
 
-`(name predicate (meta-vars ...))` — full form
-
-`(predicate-name (meta-vars ...))` — short form
+`(name predicate (meta-vars ...))` — the only acceptable form
 
 _**Syntax violations**_:
 
- 1. Clauses must have exactly one of these forms.
+ 1. Clauses must have exactly this form.
 
     — Invalid syntax of the terminal: <br/>
       <_language_> <_invalid-standalone-terminal_>
@@ -398,17 +396,12 @@ _**Syntax violations**_:
     — Name of the terminal must be an identifier: <br/>
       <_language_> <_standalone-terminal_> <_invalid-name_>
 
- 3. **predicate-name** must be an identifier.
-
-    — Terminal predicate must be a variable in short form: <br/>
-      <_language_> <_standalone-terminal_> <_invalid-predicate-name_>
-
- 4. **meta-vars** must a proper non-empty list.
+ 3. **meta-vars** must a proper non-empty list.
 
     — At least one meta-variable should be specified for a terminal: <br/>
       <_language_> <_terminal-name_>
 
- 5. Each **meta-var** must be a _meta-variable-name_.
+ 4. Each **meta-var** must be a _meta-variable-name_.
 
 
 #### Extension #######################################################
@@ -786,13 +779,9 @@ Here the rules of normalization are described in human-readable form.
 
 `(name predicate (meta-vars ...))` — full form (normalized form)
 
-`(predicate-name (meta-vars ...))` — short form
-
 _**Normalization**_:
 
- 1. Short form is converted into normalized form by assuming the
-    `predicate-name` to be both the name of the terminal and a reference
-    to its predicate.
+None.
 
 
 #### Extension #######################################################
@@ -801,13 +790,9 @@ _**Normalization**_:
 
 `(name predicate (meta-vars ...))` — full form (normalized form)
 
-`(predicate-name (meta-vars ...))` — short form
-
 _**Normalization**_:
 
- 1. Short form is converted into normalized form by assuming the
-    `predicate-name` to be both the name of the terminal and a reference
-    to its predicate.
+None.
 
 
 ##### Removal ##############################################
@@ -816,14 +801,9 @@ _**Normalization**_:
 
 `(name predicate (meta-vars ...))` — full form
 
-`(predicate-name (meta-vars ...))` — short form
-
 _**Normalization**_:
 
  1. Full form is converted into normalized form by leaving only the `name`.
-
- 2. Short form is converted into normalized form by leaving only the
-    `predicate-name` which is assumed to be the name of the terminal.
 
 
 ##### Modification #########################################

--- a/np/lang/macros/normalization.sld
+++ b/np/lang/macros/normalization.sld
@@ -25,21 +25,16 @@
     (define-syntax $normalize-standalone-terminal-definition
       (syntax-rules (quote)
         ((_ s '(name predicate meta-var-list))
-         ($ s '(name predicate meta-var-list)))
-        ((_ s '(predicate-name meta-var-list))
-         ($ s '(predicate-name predicate-name meta-var-list))) ) )
+         ($ s '(name predicate meta-var-list))) ) )
 
     (define-syntax $normalize-extension-terminal-addition
       (syntax-rules (quote)
         ((_ s '(name predicate meta-var-list))
-         ($ s '(name predicate meta-var-list)))
-        ((_ s '(predicate-name meta-var-list))
-         ($ s '(predicate-name predicate-name meta-var-list))) ) )
+         ($ s '(name predicate meta-var-list))) ) )
 
     (define-syntax $normalize-extension-terminal-removal
       (syntax-rules (quote)
         ((_ s '(name predicate meta-var-list)) ($ s 'name))
-        ((_ s '(predicate-name meta-var-list)) ($ s 'predicate-name))
         ((_ s 'name)                           ($ s 'name)) ) )
 
     (define-syntax $normalize-extension-terminal-modification

--- a/np/lang/macros/structure-terminals.sld
+++ b/np/lang/macros/structure-terminals.sld
@@ -44,7 +44,6 @@
     (define-syntax $can-be:standalone-terminal?
       (syntax-rules (quote)
         ((_ s '(name predicate (meta-vars ...))) ($ s '#t))
-        ((_ s '(predicate-name (meta-vars ...))) ($ s '#t))
         ((_ s  _)                                ($ s '#f)) ) )
 
     (define-standard-checkers %verify:standalone-terminal
@@ -56,11 +55,6 @@
          ($ s ($and '(%verify:terminal-name '(k (term . t)) 'name)
                     '(%verify:terminal-meta-var-list '(k (name . t)) '(meta-vars ...))
                     '($every? '(%verify:meta-var-name '(k (name . t))) '(meta-vars ...)) )))
-
-        ((_ s '(k t) 'term '(predicate-name (meta-vars ...)))
-         ($ s ($and '(%verify:terminal-predicate-name '(k (term . t)) 'predicate-name)
-                    '(%verify:terminal-meta-var-list '(k (predicate-name . t)) '(meta-vars ...))
-                    '($every? '(%verify:meta-var-name '(k (predicate-name . t))) '(meta-vars ...)) )))
 
         ((_ s '(k t) 'term _)
          ($ k '("Invalid syntax of the terminal" (term . t)))) ) )
@@ -164,9 +158,6 @@
 
     (define-verifier/symbol %verify:terminal-name
       ("Name of the terminal must be an identifier") )
-
-    (define-verifier/symbol %verify:terminal-predicate-name
-      ("Terminal predicate must be a variable in short form") )
 
     (define-verifier/nonempty-list %verify:terminal-meta-var-list
       ("At least one meta-variable should be specified for a terminal") )

--- a/np/lang/macros/test/define-language/test-define-language.ss
+++ b/np/lang/macros/test/define-language/test-define-language.ss
@@ -49,7 +49,7 @@
       (extends Foo)
 
       (terminals
-        (+ (number? (n))) )
+        (+ (number number? (n))) )
 
       (! (Empty Empty? ((+ g)))) )
 

--- a/np/lang/macros/test/normalization/test-normalize-terminals.ss
+++ b/np/lang/macros/test/normalization/test-normalize-terminals.ss
@@ -10,15 +10,10 @@
 
 (define-test-case (terminals:standalone "Normalization of standalone terminal forms")
 
-  (define-test ("Full form is not transformed")
+  (define-test ("Form is not transformed")
     (assert-equal '(number number? (n))
       ($ ($quote ($normalize-standalone-terminal-definition
         '(number number? (n)) ))) ) )
-
-  (define-test ("Short form: predicate name duplication")
-    (assert-equal '(number? number? (n nn))
-      ($ ($quote ($normalize-standalone-terminal-definition
-        '(number? (n nn)) ))) ) )
 )
 (verify-test-case! terminals:standalone)
 
@@ -26,15 +21,10 @@
 
 (define-test-case (terminals:extension-addition "Normalization of extension addition terminal forms")
 
-  (define-test ("Full form is not transformed")
+  (define-test ("Form is not transformed")
     (assert-equal '(number number? (n))
       ($ ($quote ($normalize-extension-terminal-addition
         '(number number? (n)) ))) ) )
-
-  (define-test ("Short form: predicate name duplication")
-    (assert-equal '(number? number? (n nn))
-      ($ ($quote ($normalize-extension-terminal-addition
-        '(number? (n nn)) ))) ) )
 )
 (verify-test-case! terminals:extension-addition)
 
@@ -51,11 +41,6 @@
     (assert-equal 'example
       ($ ($quote ($normalize-extension-terminal-removal
         '(example (lambda (x) (odd? x)) (ee)) ))) ) )
-
-  (define-test ("Short form: only name left")
-    (assert-equal 'number?
-      ($ ($quote ($normalize-extension-terminal-removal
-        '(number? (n nn)) ))) ) )
 )
 (verify-test-case! terminals:extension-removal)
 

--- a/np/lang/macros/test/partitioning/terminals/test-errors-extension-addition.ss
+++ b/np/lang/macros/test/partitioning/terminals/test-errors-extension-addition.ss
@@ -18,10 +18,10 @@
           '((+ a-symbol)) ) )) ) )
 
   (define-test ("clause")
-    (assert-syntax-error ("Invalid syntax of the terminal" lang (number number? (n nn) x))
+    (assert-syntax-error ("Invalid syntax of the terminal" lang (number? (n nn)))
       ($ ($quote
         ($partition-extension-terminal-definitions 'lang
-          '((+ (number number? (n nn) x))) ) )) ) )
+          '((+ (number? (n nn)))) ) )) ) )
 
   (define-test ("empty list")
     (assert-syntax-error ("Invalid syntax of the terminal" lang ())
@@ -54,52 +54,52 @@
 (define-test-case (terminals:extension-addition:meta-var-names "Partitioning of extension terminal addition forms: meta variable names")
 
   (define-test ("boolean")
-    (assert-syntax-error ("Name of the meta-variable must be an identifier" lang Num #t)
+    (assert-syntax-error ("Name of the meta-variable must be an identifier" lang num #t)
       ($ ($quote
         ($partition-extension-terminal-definitions 'lang
-          '((+ (Num number? (#t)))) ) )) ) )
+          '((+ (num number? (#t)))) ) )) ) )
 
   (define-test ("char")
-    (assert-syntax-error ("Name of the meta-variable must be an identifier" lang Num #\4)
+    (assert-syntax-error ("Name of the meta-variable must be an identifier" lang num #\4)
       ($ ($quote
         ($partition-extension-terminal-definitions 'lang
-          '((+ (Num number? (#\4)))) ) )) ) )
+          '((+ (num number? (#\4)))) ) )) ) )
 
   (define-test ("empty list")
-    (assert-syntax-error ("Name of the meta-variable must be an identifier" lang number? ())
+    (assert-syntax-error ("Name of the meta-variable must be an identifier" lang num ())
       ($ ($quote
         ($partition-extension-terminal-definitions 'lang
-          '((+ (number? (())))) ) )) ) )
+          '((+ (num number? (())))) ) )) ) )
 
   (define-test ("irregular list")
     (assert-syntax-error ("Name of the meta-variable must be an identifier" lang num (car . cdr))
       ($ ($quote
         ($partition-extension-terminal-definitions 'lang
-          '((+ (num (a . d) ((car . cdr))))) ) )) ) )
+          '((+ (num number? ((car . cdr))))) ) )) ) )
 
   (define-test ("list")
-    (assert-syntax-error ("Name of the meta-variable must be an identifier" lang number? (+ x))
+    (assert-syntax-error ("Name of the meta-variable must be an identifier" lang num (+ x))
       ($ ($quote
         ($partition-extension-terminal-definitions 'lang
-          '((+ (number? ((+ x))))) ) )) ) )
+          '((+ (num number? ((+ x))))) ) )) ) )
 
   (define-test ("number")
-    (assert-syntax-error ("Name of the meta-variable must be an identifier" lang Num 4)
+    (assert-syntax-error ("Name of the meta-variable must be an identifier" lang num 4)
       ($ ($quote
         ($partition-extension-terminal-definitions 'lang
-          '((+ (Num number? (4)))) ) )) ) )
+          '((+ (num number? (4)))) ) )) ) )
 
   (define-test ("string")
-    (assert-syntax-error ("Name of the meta-variable must be an identifier" lang Num "stars")
+    (assert-syntax-error ("Name of the meta-variable must be an identifier" lang num "stars")
       ($ ($quote
         ($partition-extension-terminal-definitions 'lang
-          '((+ (Num number? ("stars")))) ) )) ) )
+          '((+ (num number? ("stars")))) ) )) ) )
 
   (define-test ("vector")
-    (assert-syntax-error ("Name of the meta-variable must be an identifier" lang Num #(x))
+    (assert-syntax-error ("Name of the meta-variable must be an identifier" lang num #(x))
       ($ ($quote
         ($partition-extension-terminal-definitions 'lang
-          '((+ (Num number? (#(x))))) ) )) ) )
+          '((+ (num number? (#(x))))) ) )) ) )
 )
 (verify-test-case! terminals:extension-addition:meta-var-names)
 
@@ -108,28 +108,28 @@
 (define-test-case (terminals:extension-addition:meta-var-syntax "Partitioning of extension terminal addition forms: meta variable syntax")
 
   (define-test ("atom")
-    (assert-syntax-error ("Invalid syntax of the terminal" lang (number? foo))
+    (assert-syntax-error ("Invalid syntax of the terminal" lang (num number? foo))
       ($ ($quote
         ($partition-extension-terminal-definitions 'lang
-          '((+ (number? foo))) ) )) ) )
+          '((+ (num number? foo))) ) )) ) )
 
   (define-test ("empty list")
-    (assert-syntax-error ("At least one meta-variable should be specified for a terminal" lang number?)
+    (assert-syntax-error ("At least one meta-variable should be specified for a terminal" lang num)
       ($ ($quote
         ($partition-extension-terminal-definitions 'lang
-          '((+ (number? ()))) ) )) ) )
+          '((+ (num number? ()))) ) )) ) )
 
   (define-test ("irregular list")
-    (assert-syntax-error ("Invalid syntax of the terminal" lang (num (a . d) (car . cdr)))
+    (assert-syntax-error ("Invalid syntax of the terminal" lang (num number? (car . cdr)))
       ($ ($quote
         ($partition-extension-terminal-definitions 'lang
-          '((+ (num (a . d) (car . cdr)))) ) )) ) )
+          '((+ (num number? (car . cdr)))) ) )) ) )
 
   (define-test ("vector")
-    (assert-syntax-error ("Invalid syntax of the terminal" lang (number? #(1 2 3)))
+    (assert-syntax-error ("Invalid syntax of the terminal" lang (num number? #(1 2 3)))
       ($ ($quote
         ($partition-extension-terminal-definitions 'lang
-          '((+ (number? #(1 2 3)))) ) )) ) )
+          '((+ (num number? #(1 2 3)))) ) )) ) )
 )
 (verify-test-case! terminals:extension-addition:meta-var-syntax)
 
@@ -186,36 +186,6 @@
           '((+ (#() predicate? (some vars)))) ) )) ) )
 )
 (verify-test-case! terminals:extension-addition:name)
-
-; - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - ;
-
-(define-test-case (terminals:extension-addition:predicate "Partitioning of extension terminal addition forms: short form predicate syntax")
-
-  (define-test ("empty list")
-    (assert-syntax-error ("Terminal predicate must be a variable in short form" lang (() (some vars)) ())
-      ($ ($quote
-        ($partition-extension-terminal-definitions 'lang
-          '((+ (() (some vars)))) ) )) ) )
-
-  (define-test ("irregular list")
-    (assert-syntax-error ("Terminal predicate must be a variable in short form" lang ((a . d) (some vars)) (a . d))
-      ($ ($quote
-        ($partition-extension-terminal-definitions 'lang
-          '((+ ((a . d) (some vars)))) ) )) ) )
-
-  (define-test ("list")
-    (assert-syntax-error ("Terminal predicate must be a variable in short form" lang ((lambda (x) (odd? x)) (some vars)) (lambda (x) (odd? x)))
-      ($ ($quote
-        ($partition-extension-terminal-definitions 'lang
-          '((+ ((lambda (x) (odd? x)) (some vars)))) ) )) ) )
-
-  (define-test ("vector")
-    (assert-syntax-error ("Terminal predicate must be a variable in short form" lang (#(1 2 3) (some vars)) #(1 2 3))
-      ($ ($quote
-        ($partition-extension-terminal-definitions 'lang
-          '((+ (#(1 2 3) (some vars)))) ) )) ) )
-)
-(verify-test-case! terminals:extension-addition:predicate)
 
 ; - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - ;
 

--- a/np/lang/macros/test/partitioning/terminals/test-errors-extension-removal.ss
+++ b/np/lang/macros/test/partitioning/terminals/test-errors-extension-removal.ss
@@ -48,52 +48,52 @@
 (define-test-case (terminals:extension-removal:meta-var-names "Partitioning of extension terminal removal forms: meta variable names")
 
   (define-test ("boolean")
-    (assert-syntax-error ("Name of the meta-variable must be an identifier" lang Num #f)
+    (assert-syntax-error ("Name of the meta-variable must be an identifier" lang num #f)
       ($ ($quote
         ($partition-extension-terminal-definitions 'lang
-          '((- (Num number? (#f)))) ) )) ) )
+          '((- (num number? (#f)))) ) )) ) )
 
   (define-test ("char")
-    (assert-syntax-error ("Name of the meta-variable must be an identifier" lang Num #\q)
+    (assert-syntax-error ("Name of the meta-variable must be an identifier" lang num #\q)
       ($ ($quote
         ($partition-extension-terminal-definitions 'lang
-          '((- (Num number? (#\q)))) ) )) ) )
+          '((- (num number? (#\q)))) ) )) ) )
 
   (define-test ("empty list")
-    (assert-syntax-error ("Name of the meta-variable must be an identifier" lang number? ())
+    (assert-syntax-error ("Name of the meta-variable must be an identifier" lang num ())
       ($ ($quote
         ($partition-extension-terminal-definitions 'lang
-          '((- (number? (())))) ) )) ) )
+          '((- (num number? (())))) ) )) ) )
 
   (define-test ("irregular list")
     (assert-syntax-error ("Name of the meta-variable must be an identifier" lang num (car . cdr))
       ($ ($quote
         ($partition-extension-terminal-definitions 'lang
-          '((- (num (a . d) ((car . cdr))))) ) )) ) )
+          '((- (num number? ((car . cdr))))) ) )) ) )
 
   (define-test ("list")
-    (assert-syntax-error ("Name of the meta-variable must be an identifier" lang number? (+ x))
+    (assert-syntax-error ("Name of the meta-variable must be an identifier" lang num (+ x))
       ($ ($quote
         ($partition-extension-terminal-definitions 'lang
-          '((- (number? ((+ x))))) ) )) ) )
+          '((- (num number? ((+ x))))) ) )) ) )
 
   (define-test ("number")
-    (assert-syntax-error ("Name of the meta-variable must be an identifier" lang Num -42)
+    (assert-syntax-error ("Name of the meta-variable must be an identifier" lang num -42)
       ($ ($quote
         ($partition-extension-terminal-definitions 'lang
-          '((- (Num number? (-42)))) ) )) ) )
+          '((- (num number? (-42)))) ) )) ) )
 
   (define-test ("string")
-    (assert-syntax-error ("Name of the meta-variable must be an identifier" lang Num "have")
+    (assert-syntax-error ("Name of the meta-variable must be an identifier" lang num "have")
       ($ ($quote
         ($partition-extension-terminal-definitions 'lang
-          '((- (Num number? ("have")))) ) )) ) )
+          '((- (num number? ("have")))) ) )) ) )
 
   (define-test ("vector")
-    (assert-syntax-error ("Name of the meta-variable must be an identifier" lang Num #(x))
+    (assert-syntax-error ("Name of the meta-variable must be an identifier" lang num #(x))
       ($ ($quote
         ($partition-extension-terminal-definitions 'lang
-          '((- (Num number? (#(x))))) ) )) ) )
+          '((- (num number? (#(x))))) ) )) ) )
 )
 (verify-test-case! terminals:extension-removal:meta-var-names)
 
@@ -102,28 +102,28 @@
 (define-test-case (terminals:extension-removal:meta-var-syntax "Partitioning of extension terminal removal forms: meta variable syntax")
 
   (define-test ("atom")
-    (assert-syntax-error ("Invalid syntax of the terminal" lang (number? foo))
+    (assert-syntax-error ("Invalid syntax of the terminal" lang (num number? foo))
       ($ ($quote
         ($partition-extension-terminal-definitions 'lang
-          '((- (number? foo))) ) )) ) )
+          '((- (num number? foo))) ) )) ) )
 
   (define-test ("empty list")
-    (assert-syntax-error ("At least one meta-variable should be specified for a terminal" lang number?)
+    (assert-syntax-error ("At least one meta-variable should be specified for a terminal" lang num)
       ($ ($quote
         ($partition-extension-terminal-definitions 'lang
-          '((- (number? ()))) ) )) ) )
+          '((- (num number? ()))) ) )) ) )
 
   (define-test ("irregular list")
-    (assert-syntax-error ("Invalid syntax of the terminal" lang (num (a . d) (car . cdr)))
+    (assert-syntax-error ("Invalid syntax of the terminal" lang (num number? (car . cdr)))
       ($ ($quote
         ($partition-extension-terminal-definitions 'lang
-          '((- (num (a . d) (car . cdr)))) ) )) ) )
+          '((- (num number? (car . cdr)))) ) )) ) )
 
   (define-test ("vector")
-    (assert-syntax-error ("Invalid syntax of the terminal" lang (number? #(1 2 3)))
+    (assert-syntax-error ("Invalid syntax of the terminal" lang (num number? #(1 2 3)))
       ($ ($quote
         ($partition-extension-terminal-definitions 'lang
-          '((- (number? #(1 2 3)))) ) )) ) )
+          '((- (num number? #(1 2 3)))) ) )) ) )
 )
 (verify-test-case! terminals:extension-removal:meta-var-syntax)
 
@@ -180,36 +180,6 @@
           '((- (#() predicate? (some vars)))) ) )) ) )
 )
 (verify-test-case! terminals:extension-removal:name)
-
-; - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - ;
-
-(define-test-case (terminals:extension-removal:predicate "Partitioning of extension terminal removal forms: short form predicate syntax")
-
-  (define-test ("empty list")
-    (assert-syntax-error ("Terminal predicate must be a variable in short form" lang (() (some vars)) ())
-      ($ ($quote
-        ($partition-extension-terminal-definitions 'lang
-          '((- (() (some vars)))) ) )) ) )
-
-  (define-test ("irregular list")
-    (assert-syntax-error ("Terminal predicate must be a variable in short form" lang ((a . d) (some vars)) (a . d))
-      ($ ($quote
-        ($partition-extension-terminal-definitions 'lang
-          '((- ((a . d) (some vars)))) ) )) ) )
-
-  (define-test ("list")
-    (assert-syntax-error ("Terminal predicate must be a variable in short form" lang ((lambda (x) (odd? x)) (some vars)) (lambda (x) (odd? x)))
-      ($ ($quote
-        ($partition-extension-terminal-definitions 'lang
-          '((- ((lambda (x) (odd? x)) (some vars)))) ) )) ) )
-
-  (define-test ("vector")
-    (assert-syntax-error ("Terminal predicate must be a variable in short form" lang (#(1 2 3) (some vars)) #(1 2 3))
-      ($ ($quote
-        ($partition-extension-terminal-definitions 'lang
-          '((- (#(1 2 3) (some vars)))) ) )) ) )
-)
-(verify-test-case! terminals:extension-removal:predicate)
 
 ; - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - ;
 

--- a/np/lang/macros/test/partitioning/terminals/test-errors-standalone.ss
+++ b/np/lang/macros/test/partitioning/terminals/test-errors-standalone.ss
@@ -54,52 +54,52 @@
 (define-test-case (terminals:standalone:meta-var-names "Partitioning of standalone terminal forms: meta-variable names")
 
   (define-test ("boolean")
-    (assert-syntax-error ("Name of the meta-variable must be an identifier" lang Num #t)
+    (assert-syntax-error ("Name of the meta-variable must be an identifier" lang num #t)
       ($ ($quote
         ($filter-standalone-terminal-definitions 'lang
-          '((Num number? (#t))) ) )) ) )
+          '((num number? (#t))) ) )) ) )
 
   (define-test ("char")
-    (assert-syntax-error ("Name of the meta-variable must be an identifier" lang Num #\x1234)
+    (assert-syntax-error ("Name of the meta-variable must be an identifier" lang num #\x1234)
       ($ ($quote
         ($filter-standalone-terminal-definitions 'lang
-          '((Num number? (#\x1234))) ) )) ) )
+          '((num number? (#\x1234))) ) )) ) )
 
   (define-test ("empty list")
-    (assert-syntax-error ("Name of the meta-variable must be an identifier" lang number? ())
+    (assert-syntax-error ("Name of the meta-variable must be an identifier" lang num ())
       ($ ($quote
         ($filter-standalone-terminal-definitions 'lang
-          '((number? (()))) ) )) ) )
+          '((num number? (()))) ) )) ) )
 
   (define-test ("irregular list")
     (assert-syntax-error ("Name of the meta-variable must be an identifier" lang num (car . cdr))
       ($ ($quote
         ($filter-standalone-terminal-definitions 'lang
-          '((num (car . cdr) ((car . cdr)))) ) )) ) )
+          '((num number? ((car . cdr)))) ) )) ) )
 
   (define-test ("list")
-    (assert-syntax-error ("Name of the meta-variable must be an identifier" lang number (+ x))
+    (assert-syntax-error ("Name of the meta-variable must be an identifier" lang num (+ x))
       ($ ($quote
         ($filter-standalone-terminal-definitions 'lang
-          '((number number? ((+ x)))) ) )) ) )
+          '((num number? ((+ x)))) ) )) ) )
 
   (define-test ("number")
-    (assert-syntax-error ("Name of the meta-variable must be an identifier" lang Num -6)
+    (assert-syntax-error ("Name of the meta-variable must be an identifier" lang num -6)
       ($ ($quote
         ($filter-standalone-terminal-definitions 'lang
-          '((Num number? (-6))) ) )) ) )
+          '((num number? (-6))) ) )) ) )
 
   (define-test ("string")
-    (assert-syntax-error ("Name of the meta-variable must be an identifier" lang Num "then")
+    (assert-syntax-error ("Name of the meta-variable must be an identifier" lang num "then")
       ($ ($quote
         ($filter-standalone-terminal-definitions 'lang
-          '((Num number? ("then"))) ) )) ) )
+          '((num number? ("then"))) ) )) ) )
 
   (define-test ("vector")
-    (assert-syntax-error ("Name of the meta-variable must be an identifier" lang Num #(x))
+    (assert-syntax-error ("Name of the meta-variable must be an identifier" lang num #(x))
       ($ ($quote
         ($filter-standalone-terminal-definitions 'lang
-          '((Num number? (#(x)))) ) )) ) )
+          '((num number? (#(x)))) ) )) ) )
 )
 (verify-test-case! terminals:standalone:meta-var-names)
 
@@ -108,16 +108,16 @@
 (define-test-case (terminals:standalone:meta-var-syntax "Partitioning of standalone terminal forms: meta-variable syntax")
 
   (define-test ("atom")
-    (assert-syntax-error ("Invalid syntax of the terminal" lang (number? foo))
+    (assert-syntax-error ("Invalid syntax of the terminal" lang (number number? foo))
       ($ ($quote
         ($filter-standalone-terminal-definitions 'lang
-          '((number? foo)) ) )) ) )
+          '((number number? foo)) ) )) ) )
 
   (define-test ("empty")
-    (assert-syntax-error ("At least one meta-variable should be specified for a terminal" lang number?)
+    (assert-syntax-error ("At least one meta-variable should be specified for a terminal" lang number)
       ($ ($quote
         ($filter-standalone-terminal-definitions 'lang
-          '((number? ())) ) )) ) )
+          '((number number? ())) ) )) ) )
 
   (define-test ("irregular list")
     (assert-syntax-error ("Invalid syntax of the terminal" lang (number number? (a b . c)))
@@ -126,10 +126,10 @@
           '((number number? (a b . c))) ) )) ) )
 
   (define-test ("vector")
-    (assert-syntax-error ("Invalid syntax of the terminal" lang (number? #(1 2 3)))
+    (assert-syntax-error ("Invalid syntax of the terminal" lang (number number? #(1 2 3)))
       ($ ($quote
         ($filter-standalone-terminal-definitions 'lang
-          '((number? #(1 2 3))) ) )) ) )
+          '((number number? #(1 2 3))) ) )) ) )
 )
 (verify-test-case! terminals:standalone:meta-var-syntax)
 
@@ -186,33 +186,3 @@
           '((#() predicate? (some vars))) ) )) ) )
 )
 (verify-test-case! terminals:standalone:name)
-
-; - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - ;
-
-(define-test-case (terminals:standalone:predicate "Partitioning of standalone terminal forms: short form predicate syntax")
-
-  (define-test ("empty list")
-    (assert-syntax-error ("Terminal predicate must be a variable in short form" lang (() (some vars)) ())
-      ($ ($quote
-        ($filter-standalone-terminal-definitions 'lang
-          '((() (some vars))) ) )) ) )
-
-  (define-test ("irregular list")
-    (assert-syntax-error ("Terminal predicate must be a variable in short form" lang ((a . d) (some vars)) (a . d))
-      ($ ($quote
-        ($filter-standalone-terminal-definitions 'lang
-          '(((a . d) (some vars))) ) )) ) )
-
-  (define-test ("list")
-    (assert-syntax-error ("Terminal predicate must be a variable in short form" lang ((lambda (x) (odd? x)) (some vars)) (lambda (x) (odd? x)))
-      ($ ($quote
-        ($filter-standalone-terminal-definitions 'lang
-          '(((lambda (x) (odd? x)) (some vars))) ) )) ) )
-
-  (define-test ("vector")
-    (assert-syntax-error ("Terminal predicate must be a variable in short form" lang (#(1 2 3) (some vars)) #(1 2 3))
-      ($ ($quote
-        ($filter-standalone-terminal-definitions 'lang
-          '((#(1 2 3) (some vars))) ) )) ) )
-)
-(verify-test-case! terminals:standalone:predicate)

--- a/np/lang/macros/test/partitioning/terminals/test-partition-terminals.ss
+++ b/np/lang/macros/test/partitioning/terminals/test-partition-terminals.ss
@@ -19,31 +19,26 @@
       ($ ($quote ($filter-standalone-terminal-definitions 'lang
         '((number number? (n))) ))) ) )
 
-  (define-test ("accepts short form")
-    (assert-equal '((number? (n nn)))
-      ($ ($quote ($filter-standalone-terminal-definitions 'lang
-        '((number? (n nn))) ))) ) )
-
   (define-test ("accepts expressions in full form")
     (assert-equal '((odd-number (lambda (x) (and (number? x) (odd? x))) (o-n)))
       ($ ($quote ($filter-standalone-terminal-definitions 'lang
         '((odd-number (lambda (x) (and (number? x) (odd? x))) (o-n))) ))) ) )
 
   (define-test ("leaves clauses in order")
-    (assert-equal '((terminal1 (v11 v12 v13))
-                    (terminal2 (v21 v22 v23))
-                    (terminal3 (v31 v32 v33)))
+    (assert-equal '((terminal1 pred1 (v11 v12 v13))
+                    (terminal2 pred2 (v21 v22 v23))
+                    (terminal3 pred3 (v31 v32 v33)))
       ($ ($quote ($filter-standalone-terminal-definitions 'lang
-        '((terminal1 (v11 v12 v13))
-          (terminal2 (v21 v22 v23))
-          (terminal3 (v31 v32 v33))) ))) ) )
+        '((terminal1 pred1 (v11 v12 v13))
+          (terminal2 pred2 (v21 v22 v23))
+          (terminal3 pred3 (v31 v32 v33))) ))) ) )
 
   (define-test ("accepts peculiar extension-like forms")
     (assert-equal '((+ (Look like (extension forms))
-                    (while in fact)) (- (they are not)))
+                    (while in fact)) (- (they are) (not)))
       ($ ($quote ($filter-standalone-terminal-definitions 'lang
         '((+ (Look like (extension forms)) (while in fact))
-          (- (they are not))) ))) ) )
+          (- (they are) (not))) ))) ) )
 )
 (verify-test-case! terminals:standalone)
 
@@ -52,16 +47,16 @@
 (define-test-case (terminals:extension-addition "Partitioning of extension addition terminal forms")
 
   (define-test ("recognizes addition forms")
-    (assert-equal '(((number? (n)) (symbol symbol? (s))) () ())
+    (assert-equal '(((number number? (n)) (symbol symbol? (s))) () ())
       ($ ($quote ($partition-extension-terminal-definitions 'lang
-        '((+ (number? (n)))
+        '((+ (number number? (n)))
           (+ (symbol symbol? (s)))) ))) ) )
 
   (define-test ("recognizes addition forms with multiple definitions")
-    (assert-equal '(((number? (n)) (symbol? (s))) () ())
+    (assert-equal '(((number number? (n)) (symbol symbol? (s))) () ())
       ($ ($quote ($partition-extension-terminal-definitions 'lang
-        '((+ (number? (n))
-             (symbol? (s)) )) ))) ) )
+        '((+ (number number? (n))
+             (symbol symbol? (s)) )) ))) ) )
 )
 (verify-test-case! terminals:extension-addition)
 
@@ -75,10 +70,10 @@
         '((- (void (lambda (x) (odd? x)) (v)))) ))) ) )
 
   (define-test ("recognizes full removal forms with multiple definitions")
-    (assert-equal '(() ((void (lambda (x) (odd? x)) (v)) (term? (t tt))) ())
+    (assert-equal '(() ((void (lambda (x) (odd? x)) (v)) (term term? (t tt))) ())
       ($ ($quote ($partition-extension-terminal-definitions 'lang
         '((- (void (lambda (x) (odd? x)) (v))
-             (term? (t tt)))) ))) ) )
+             (term term? (t tt)))) ))) ) )
 
   (define-test ("recognizes short removal forms")
     (assert-equal '(() (some removed terminals) ())
@@ -86,9 +81,9 @@
         '((- some removed) (- terminals)) ))) ) )
 
   (define-test ("recognizes mixed removal forms")
-    (assert-equal '(() (some removed (terminal? (t))) ())
+    (assert-equal '(() (some removed (terminal terminal? (t))) ())
       ($ ($quote ($partition-extension-terminal-definitions 'lang
-        '((- some removed (terminal? (t)))) ))) ) )
+        '((- some removed (terminal terminal? (t)))) ))) ) )
 )
 (verify-test-case! terminals:extension-removal)
 
@@ -129,12 +124,12 @@
       ($ ($quote ($partition-extension-terminal-definitions 'lang '()))) ) )
 
   (define-test ("can handle all forms altogether")
-    (assert-equal '(((tar var? (x)) (x (x)))
-                    (some removed (terminal? (t)))
+    (assert-equal '(((tar var? (x)) (x x (x)))
+                    (some removed (term terminal? (t)))
                     ((zog (() (var)))))
       ($ ($quote ($partition-extension-terminal-definitions 'lang
-        '((- some removed) (+ (tar var? (x))) (- (terminal? (t)))
-          (! (zog ((- var)))) (+ (x (x)))) ))) ) )
+        '((- some removed) (+ (tar var? (x))) (- (term terminal? (t)))
+          (! (zog ((- var)))) (+ (x x (x)))) ))) ) )
 
   (define-test ("has not restrictions on terminal naming")
     (assert-equal '(((+ + (+))) ((- - (-))) ((! ((+) (-)))))

--- a/np/lang/macros/test/partitioning/toplevel/test-partition-toplevel.ss
+++ b/np/lang/macros/test/partitioning/toplevel/test-partition-toplevel.ss
@@ -60,21 +60,21 @@
         ($partition-toplevel-clauses 'lang '((terminals) (terminals))) )) ) )
 
   (define-test ("squashes 'terminals' contents")
-    (assert-equal '(#f #f #f #f ((num number? (n)) (sym symbol? (s)) (null? (x))) ())
+    (assert-equal '(#f #f #f #f ((num number? (n)) (sym symbol? (s)) (null null? (x))) ())
       ($ ($quote
         ($partition-toplevel-clauses 'lang '((terminals (num number? (n))
                                                         (sym symbol? (s)))
                                              (terminals)
-                                             (terminals (null? (x))))) )) ) )
+                                             (terminals (null null? (x))))) )) ) )
 
   (define-test ("recognizes extension 'terminals' clause")
     (assert-equal '(#f #f #f #f ((+ (num number? (n))
-                                    (null? (x)) )
+                                    (null null? (x)) )
                                  (void void? ((+ vv)))
                                  (- some other terms)) ())
       ($ ($quote
         ($partition-toplevel-clauses 'lang '((terminals (+ (num number? (n))
-                                                           (null? (x)) )
+                                                           (null null? (x)) )
                                                         (void void? ((+ vv)))
                                                         (- some other terms) ))) )) ) )
 )
@@ -116,13 +116,13 @@
 
   (define-test ("clause order is (mostly) irrelevant")
     (assert-equal '((another-lang) (lang?) (parse-lang) #f
-                    ((null? (x))) ((Pair Pair? (p) (x x))
+                    ((null null? (x))) ((Pair Pair? (p) (x x))
                                    (- Some Non Terminals)
                                    (+ (Num-Pair (np) (n n)))))
       ($ ($quote
         ($partition-toplevel-clauses 'lang
           '((terminals)               (Pair Pair? (p) (x x))
-            (parser parse-lang)       (terminals (null? (x)))
+            (parser parse-lang)       (terminals (null null? (x)))
             (predicate lang?)         (- Some Non Terminals)
             (+ (Num-Pair (np) (n n))) (extends another-lang)) ) )) ) )
 


### PR DESCRIPTION
I mean that one where terminal name is inferred from the predicate which is required to be specified as variable binding:

``` scheme
(define-language Lang
  (terminals
    (number? (n)) ) )
```

Initially I thought this would be a good shortcut for terminals like this, which are based on some pre-existing predicates.

However, this led to another idea of treating `number` and `number?` as equal with intent to avoid referring to names with question mark. But such special comparison itself leads to issues. However, I still think that terminals named `number?` are bad.

So I have decided to ditch this extension away. The user now must specify terminal names explicitly. This avoids the issue, allows to compare names with `eq?`, and shaves off some macro code.
